### PR TITLE
fix(dispatcher): supress memory leak warning of EventEmitter

### DIFF
--- a/src/Dispatcher.js
+++ b/src/Dispatcher.js
@@ -42,6 +42,13 @@ export default class Dispatcher extends EventEmitter {
         return false;
     }
 
+    constructor() {
+        super();
+        // suppress: memory leak warning of EventEmitter
+        // Dispatcher can listen more than 10 events
+        this.setMaxListeners(0);
+    }
+
     /**
      * add onAction handler and return unbind function
      * @param {{function(payload: DispatcherPayload)}} payloadHandler


### PR DESCRIPTION
Dispatcher/Context/StoreGroup/Store/UseCase can listen more than 10 events

This pull request supresss following warning

> (node) warning: possible EventEmitter memory leak detected. 11 listeners added. Use emitter.setMaxListeners() to increase limit.