### PR TITLE
fix(dispatcher): drop `payload.type` limitation

### DIFF
--- a/src/Dispatcher.js
+++ b/src/Dispatcher.js
@@ -6,7 +6,7 @@ export const ON_DISPATCH = "__ON_DISPATCH__";
 /**
  * payload The payload object that must have `type` property.
  * @typedef {Object} DispatcherPayload
- * @property {String} type The event type to dispatch.
+ * @property {*} type The event type to dispatch.
  * @public
  */
 /**
@@ -68,7 +68,7 @@ export default class Dispatcher extends EventEmitter {
      */
     dispatch(payload) {
         assert(payload !== undefined && payload !== null, "payload should not null or undefined");
-        assert(typeof payload.type === "string", "payload's type should be string");
+        assert(typeof payload.type !== "undefined", "payload's `type` should be required");
         this.emit(ON_DISPATCH, payload);
     }
 

--- a/test/Dispatcher-test.js
+++ b/test/Dispatcher-test.js
@@ -26,6 +26,17 @@ describe("Dispatcher", function () {
                 assert(error.message !== "UNREACHED");
             }
         });
+        it("should dispatch with payload object that has type propery", function (done) {
+            const dispatcher = new Dispatcher();
+            const expectedPayload = {
+                type: { /* string Symbol anything */ }
+            };
+            dispatcher.onDispatch(payload => {
+                assert.deepEqual(payload, expectedPayload);
+                done();
+            });
+            dispatcher.dispatch(expectedPayload);
+        });
         it("should pass payload object to listening handler", function (done) {
             const dispatcher = new Dispatcher();
             const expectedPayload = {


### PR DESCRIPTION
Allow to use any type data to `payload.type`.

You can write following now!

```js
const dispatcher = new Dispatcher();
const expectedPayload = {
    type: { /* string Symbol anything */ }
};
dispatcher.onDispatch(payload => {
    assert.deepEqual(payload, expectedPayload);
    done();
});
dispatcher.dispatch(expectedPayload);
```
