### PR TITLE
feat(StoreGroup): Add QueuedStoreGroup

### DIFF
--- a/example/svg-feeling/src/js/store/AppStoreGroup.js
+++ b/example/svg-feeling/src/js/store/AppStoreGroup.js
@@ -1,6 +1,6 @@
 // LICENSE : MIT
 "use strict";
-import {StoreGroup} from "almin";
+import {QueuedStoreGroup} from "almin";
 import colorMixerRepository from "../infra/ColorMixerRepository";
 import ColorStore from "./ColorStore/ColorStore";
 import ColorHistoryStore from "./ColorHistoryStore/ColorHistoryStore";
@@ -10,7 +10,7 @@ export default class AppStoreGroup {
      * @returns {StoreGroup}
      */
     constructor() {
-        return new StoreGroup(AppStoreGroup.create());
+        return new QueuedStoreGroup(AppStoreGroup.create());
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "zuul": "^3.10.1"
   },
   "dependencies": {
+    "is-promise": "^2.1.0",
     "lru-cache": "^4.0.1",
     "object-assign": "^4.1.0"
   }

--- a/perf/node-memory-leak-testing/QueuedStoreGroup-memory-test.js
+++ b/perf/node-memory-leak-testing/QueuedStoreGroup-memory-test.js
@@ -7,7 +7,8 @@
 const assert = require("assert");
 const pretty = require('prettysize');
 const Store = require("almin").Store;
-const StoreGroup = require("almin").StoreGroup;
+const QueuedStoreGroup = require("almin").QueuedStoreGroup;
+console.log("= QueuedStoreGroup perf test");
 const gc = () => {
     if (global.gc) {
         global.gc();
@@ -31,7 +32,7 @@ class BStore extends Store {
 }
 const aStore = new AStore();
 const bStore = new BStore();
-const storeGroup = new StoreGroup([aStore, bStore]);
+const storeGroup = new QueuedStoreGroup([aStore, bStore]);
 let currentState = storeGroup.getState();
 
 // ========= START ===========

--- a/perf/node-memory-leak-testing/StoreGroup-memory-test.js
+++ b/perf/node-memory-leak-testing/StoreGroup-memory-test.js
@@ -1,0 +1,68 @@
+"use strict";
+/*
+    Test memory leak of StoreGroup cache.
+
+    assert(startMemory - endMemory < 10MB);
+ */
+const assert = require("assert");
+const pretty = require('prettysize');
+const Store = require("almin").Store;
+const StoreGroup = require("almin").StoreGroup;
+console.log("= StoreGroup perf test");
+const gc = () => {
+    if (global.gc) {
+        global.gc();
+    } else {
+        console.log('Garbage collection unavailable.  Pass --expose-gc '
+            + 'when launching node to enable forced garbage collection.');
+    }
+};
+const usage = () => {
+    return pretty(process.memoryUsage().heapTotal);
+};
+class AStore extends Store {
+    getState() {
+        return {a: "a value"};
+    }
+}
+class BStore extends Store {
+    getState() {
+        return {b: Math.random()};
+    }
+}
+const aStore = new AStore();
+const bStore = new BStore();
+const storeGroup = new StoreGroup([aStore, bStore]);
+let currentState = storeGroup.getState();
+
+// ========= START ===========
+const startHeapTotal = process.memoryUsage().heapTotal;
+
+const perfMemory = () => {
+    // before
+    gc();
+    console.log("before", usage());
+    for (let i = 0; i < 10000; i++) {
+        aStore.emitChange();
+        bStore.emitChange();
+        storeGroup.emitChange();
+        currentState = storeGroup.getState();
+    }
+    console.log("after", usage());
+    gc();
+    console.log("after:gc", usage());
+    console.log("----------------------------------");
+};
+
+for (let i = 0; i < 10; i++) {
+    perfMemory();
+}
+gc();
+
+setTimeout(() => {
+    const diffHeapMemory = process.memoryUsage().heapTotal - startHeapTotal;
+    const MB = 1024 * 1000 * 10;
+    console.log("finish", usage());
+    console.log("diffMemory:", pretty(diffHeapMemory));
+    assert(diffHeapMemory < MB, "after gc(), HeapMemory diff should be less 10MB");
+}, 10);

--- a/perf/node-memory-leak-testing/package.json
+++ b/perf/node-memory-leak-testing/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "pretest": "rm-local-modules && npm i",
-    "perf": "node --expose-gc test.js",
+    "perf": "node --expose-gc StoreGroup-memory-test.js && node --expose-gc QueuedStoreGroup-memory-test.js",
     "test": "npm run perf"
   },
   "author": "azu",

--- a/src/Context.js
+++ b/src/Context.js
@@ -69,7 +69,11 @@ export default class Context {
      */
     useCase(useCase) {
         assert(UseCase.isUseCase(useCase), `It should be instance of UseCase: ${useCase}`);
-        return new UseCaseExecutor(useCase, this._dispatcher);
+        return new UseCaseExecutor({
+            useCase,
+            parent: null,
+            dispatcher: this._dispatcher
+        });
     }
 
     /**

--- a/src/UILayer/QueuedStoreGroup.js
+++ b/src/UILayer/QueuedStoreGroup.js
@@ -32,6 +32,7 @@ const defaultOptions = {
  * QueuedStoreGroup has event queue system.
  * QueuedStoreGroup not dependant on async function like `setTimeout`.
  * QueuedStoreGroup work as Sync or Async.
+ * QueuedStoreGroup prefer strict design than ./StoreGroup.js
  *
  * ## Note
  * - QueuedStoreGroup not allow to change **stores** directly.

--- a/src/UILayer/QueuedStoreGroup.js
+++ b/src/UILayer/QueuedStoreGroup.js
@@ -1,0 +1,189 @@
+// LICENSE : MIT
+"use strict";
+// polyfill Object.assign
+const ObjectAssign = require("object-assign");
+const assert = require("assert");
+const LRU = require("lru-cache");
+const CHANGE_STORE_GROUP = "CHANGE_STORE_GROUP";
+import Dispatcher from "./../Dispatcher";
+import Store from "./../Store";
+import StoreGroupValidator from "./StoreGroupValidator";
+import {ActionTypes} from "../Context";
+/**
+ * StoreGroup is a **UI** parts of Store.
+ * StoreGroup has event queue system.
+ * It means that StoreGroup thin out change events of stores.
+ * If you want to know all change events, and directly use `store.onChange()`.
+ * @public
+ */
+export default class QueuedStoreGroup extends Dispatcher {
+    /**
+     * Create StoreGroup
+     * @param {Store[]} stores stores are instance of `Store` class
+     */
+    constructor(stores) {
+        super();
+        StoreGroupValidator.validateStores(stores);
+        /**
+         * callable release handlers
+         * @type {Function[]}
+         * @private
+         */
+        this._releaseHandlers = [];
+
+        /**
+         * array of store that emit change in now!
+         * this array is temporary cache in changing the StoreGroup
+         * @type {Store[]}
+         * @private
+         */
+        this._currentChangingStores = [];
+        /**
+         * @type {Store[]}
+         */
+        this.stores = stores;
+        // listen onChange of each store.
+        this.stores.forEach(store => this._registerStore(store));
+        /**
+         * LRU Cache for Store and State
+         * @type {LRU}
+         * @private
+         */
+        this._stateCache = new LRU({
+            max: 100,
+            maxAge: 1000 * 60 * 60
+        });
+        // `this` can catch the events of dispatchers
+        // Because context delegate dispatched events to **this**
+        const didExecutedUseCase = (payload) => {
+            if (payload.type === ActionTypes.ON_DID_EXECUTE_EACH_USECASE) {
+                const parent = payload.parent;
+                // emitChange when root useCase is executed
+                // ignore child useCase is executing
+                if (!parent) {
+                    this.emitChange();
+                }
+            }
+        };
+        this.onDispatch(didExecutedUseCase);
+    }
+
+    /**
+     * Return current changing stores.
+     * @returns {Store[]}
+     */
+    get currentChangingStores() {
+        return this._currentChangingStores;
+    }
+
+    /**
+     * return the state object that merge each stores's state
+     * @returns {Object} merged state object
+     */
+    getState() {
+        const stateMap = this.stores.map(store => {
+            /*
+             Why record nextState to `_storeValueMap`?
+             It is for Use Store's getState(prevState) implementation.
+             */
+            const prevState = this._stateCache.get(store);
+            // if the `store` is changed in previous
+            if (prevState && this.currentChangingStores.indexOf(store) === -1) {
+                return prevState;
+            }
+            const nextState = store.getState(prevState);
+            assert(typeof nextState == "object", `${store}: ${store.name}.getState() should return Object.
+e.g.)
+
+ class ExampleStore extends Store {
+     getState(prevState) {
+         return {
+            StateName: state
+         };
+     }
+ }
+ 
+Then, use can access by StateName.
+
+StoreGroup#getState()["StateName"]; // state
+
+`);
+            this._stateCache.set(store, nextState);
+            return nextState;
+        });
+        return ObjectAssign({}, ...stateMap);
+    }
+
+    /**
+     * register store and listen onChange.
+     * If you release store, and do call {@link release} method.
+     * @param {Store} store
+     * @private
+     */
+    _registerStore(store) {
+        // if anyone store is changed, will call `emitChange()`.
+        const releaseOnChangeHandler = store.onChange(() => {
+            // ====
+            // prune previous cache
+            if (!this._isAnyOneStoreChanged) {
+                this._pruneCurrentChangingStores();
+            }
+            this._isAnyOneStoreChanged = true;
+            // =====
+            // if the same store emit multiple, emit only once.
+            const isStoreAlreadyChanging = this._currentChangingStores.indexOf(store) !== -1;
+            if (isStoreAlreadyChanging) {
+                return;
+            }
+            // add change store list in now
+            // it is released by `StoreGroup#emitChange`
+            this._currentChangingStores.push(store);
+        });
+        // Implementation Note:
+        // Delegate dispatch event to Store from StoreGroup
+        // Dispatcher -> StoreGroup -> Store
+        const releaseOnDispatchHandler = this.pipe(store);
+        // add release handler
+        this._releaseHandlers = this._releaseHandlers.concat([releaseOnChangeHandler, releaseOnDispatchHandler]);
+    }
+
+    emitChange() {
+        const changingStores = this._currentChangingStores.slice();
+        // release ownership  of changingStores from StoreGroup
+        // transfer ownership of changingStores to other
+        this.emit(CHANGE_STORE_GROUP, changingStores);
+        // reset changed state flag
+        this._isAnyOneStoreChanged = false;
+    }
+
+    /**
+     * listen changes of the store group.
+     * @param {function(stores: Store[])} handler the callback arguments is array of changed store.
+     * @returns {Function} call the function and release handler
+     */
+    onChange(handler) {
+        this.on(CHANGE_STORE_GROUP, handler);
+        const releaseHandler = this.removeListener.bind(this, CHANGE_STORE_GROUP, handler);
+        this._releaseHandlers.push(releaseHandler);
+        return releaseHandler;
+    }
+
+    /**
+     * release all events handler.
+     * You can call this when no more call event handler
+     * @public
+     */
+    release() {
+        this._releaseHandlers.forEach(releaseHandler => releaseHandler());
+        this._releaseHandlers.length = 0;
+        this._stateCache.reset();
+    }
+
+    /**
+     * prune changing stores
+     * @private
+     */
+    _pruneCurrentChangingStores() {
+        this._currentChangingStores.length = 0;
+    }
+}

--- a/src/UILayer/QueuedStoreGroup.js
+++ b/src/UILayer/QueuedStoreGroup.js
@@ -60,12 +60,21 @@ export default class QueuedStoreGroup extends Dispatcher {
                 const parent = payload.parent;
                 // emitChange when root useCase is executed
                 // ignore child useCase is executing
-                if (!parent) {
+                if (!parent && this.hasChangingStore) {
                     this.emitChange();
                 }
             }
         };
-        this.onDispatch(didExecutedUseCase);
+        const unListenOnDispatch = this.onDispatch(didExecutedUseCase);
+        this._releaseHandlers.push(unListenOnDispatch);
+    }
+
+    /**
+     * Return true if has changing stores at least once
+     * @returns {boolean}
+     */
+    get hasChangingStore() {
+        return this.currentChangingStores.length !== 0;
     }
 
     /**

--- a/src/UILayer/QueuedStoreGroup.js
+++ b/src/UILayer/QueuedStoreGroup.js
@@ -26,10 +26,16 @@ const defaultOptions = {
     asap: false
 };
 /**
- * StoreGroup is a **UI** parts of Store.
- * StoreGroup has event queue system.
- * It means that StoreGroup thin out change events of stores.
- * If you want to know all change events, and directly use `store.onChange()`.
+ * ## Description
+ *
+ * QueuedStoreGroup is a **UI** parts of Store.
+ * QueuedStoreGroup has event queue system.
+ * QueuedStoreGroup not dependant on async function like `setTimeout`.
+ * QueuedStoreGroup work as Sync or Async.
+ *
+ * ## Note
+ * - QueuedStoreGroup not allow to change **stores** directly.
+ * - Always change **stores** vis execution of UseCase.
  * @public
  */
 export default class QueuedStoreGroup extends Dispatcher {

--- a/src/UILayer/QueuedStoreGroup.js
+++ b/src/UILayer/QueuedStoreGroup.js
@@ -35,7 +35,7 @@ const defaultOptions = {
  *
  * ## Note
  * - QueuedStoreGroup not allow to change **stores** directly.
- * - Always change **stores** vis execution of UseCase.
+ * - Always change **stores** via execution of UseCase.
  * @public
  */
 export default class QueuedStoreGroup extends Dispatcher {

--- a/src/UseCaseContext.js
+++ b/src/UseCaseContext.js
@@ -1,7 +1,7 @@
 // LICENSE : MIT
 "use strict";
 /*
-    This class aim to execute other UseCase in the UseCase
+ This class aim to execute other UseCase in the UseCase
  */
 import UseCaseExecutor from "./UseCaseExecutor";
 import Dispatcher from "./Dispatcher";
@@ -21,6 +21,10 @@ export default class UseCaseContext {
      */
     useCase(useCase) {
         assert(useCase !== this.dispatcher, `the useCase(${useCase}) should not equal this useCase(${this.dispatcher})`);
-        return new UseCaseExecutor(useCase, this.dispatcher);
+        return new UseCaseExecutor({
+            useCase,
+            parent: this.dispatcher,
+            dispatcher: this.dispatcher
+        });
     }
 }

--- a/src/UseCaseExecutor.js
+++ b/src/UseCaseExecutor.js
@@ -35,8 +35,9 @@ export default class UseCaseExecutor {
         this.parentUseCase = parent;
         /**
          * @type {Dispatcher}
+         * @private
          */
-        this.parentDispatcher = dispatcher;
+        this.disptcher = dispatcher;
 
         /**
          * is the useCase executed
@@ -52,7 +53,7 @@ export default class UseCaseExecutor {
          */
         this._releaseHandlers = [];
         // delegate userCase#onDispatch to central dispatcher
-        const unListenHandler = this.useCase.pipe(this.parentDispatcher);
+        const unListenHandler = this.useCase.pipe(this.disptcher);
         this._releaseHandlers.push(unListenHandler);
     }
 
@@ -61,7 +62,7 @@ export default class UseCaseExecutor {
      */
     willExecute(args) {
         // emit event for System
-        this.parentDispatcher.dispatch({
+        this.disptcher.dispatch({
             type: ActionTypes.ON_WILL_EXECUTE_EACH_USECASE,
             useCase: this.useCase,
             parent: this.parentUseCase,
@@ -76,7 +77,7 @@ export default class UseCaseExecutor {
         if (this._isExecuted) {
             return;
         }
-        this.parentDispatcher.dispatch({
+        this.disptcher.dispatch({
             type: ActionTypes.ON_DID_EXECUTE_EACH_USECASE,
             useCase: this.useCase,
             parent: this.parentUseCase
@@ -89,7 +90,7 @@ export default class UseCaseExecutor {
      * @param {function(useCase: UseCase, args: *)} handler
      */
     onWillExecuteEachUseCase(handler) {
-        const releaseHandler = this.parentDispatcher.onDispatch(function onWillExecuteEachUseCaseInUseCaseExecutor(payload) {
+        const releaseHandler = this.disptcher.onDispatch(function onWillExecuteEachUseCaseInUseCaseExecutor(payload) {
             if (payload.type === ActionTypes.ON_WILL_EXECUTE_EACH_USECASE) {
                 handler(payload.useCase, payload.args);
             }
@@ -103,7 +104,7 @@ export default class UseCaseExecutor {
      * @param {function(useCase: UseCase)} handler
      */
     onDidExecuteEachUseCase(handler) {
-        const releaseHandler = this.parentDispatcher.onDispatch(function onDidExecuteEachUseCaseInUseCaseExecutor(payload) {
+        const releaseHandler = this.disptcher.onDispatch(function onDidExecuteEachUseCaseInUseCaseExecutor(payload) {
             if (payload.type === ActionTypes.ON_DID_EXECUTE_EACH_USECASE) {
                 handler(payload.useCase);
             }

--- a/src/UseCaseExecutor.js
+++ b/src/UseCaseExecutor.js
@@ -1,15 +1,21 @@
 // LICENSE : MIT
 "use strict";
 const assert = require("assert");
+const isPromise = require('is-promise');
 import {ActionTypes} from "./Context";
 import Dispatcher from "./Dispatcher";
 import UseCase from "./UseCase";
 export default class UseCaseExecutor {
     /**
      * @param {UseCase} useCase
-     * @param {Dispatcher|UseCase} parentDispatcher is parent dispatcher-like object
+     * @param {UseCase|null} parent parent is parent of `useCase`
+     * @param {Dispatcher|UseCase} dispatcher
      */
-    constructor(useCase, parentDispatcher) {
+    constructor({
+        useCase,
+        parent,
+        dispatcher
+    }) {
         // execute and finish =>
         const useCaseName = useCase.name;
         assert(typeof useCaseName === "string", "UseCase instance should have constructor.name " + useCase);
@@ -22,10 +28,23 @@ export default class UseCaseExecutor {
          * @type {UseCase} executable useCase
          */
         this.useCase = useCase;
+
+        /**
+         * @type {UseCase|null} parent useCase
+         */
+        this.parentUseCase = parent;
         /**
          * @type {Dispatcher}
          */
-        this.parentDispatcher = parentDispatcher;
+        this.parentDispatcher = dispatcher;
+
+        /**
+         * is the useCase executed
+         * @type {boolean}
+         * @private
+         */
+        this._isExecuted = false;
+
         /**
          * callable release handlers that are called in release()
          * @type {Function[]}
@@ -45,18 +64,24 @@ export default class UseCaseExecutor {
         this.parentDispatcher.dispatch({
             type: ActionTypes.ON_WILL_EXECUTE_EACH_USECASE,
             useCase: this.useCase,
+            parent: this.parentUseCase,
             args
         });
     }
 
     /**
-     *
+     * dispatch did execute each UseCase at once
      */
     didExecute() {
+        if (this._isExecuted) {
+            return;
+        }
         this.parentDispatcher.dispatch({
             type: ActionTypes.ON_DID_EXECUTE_EACH_USECASE,
-            useCase: this.useCase
+            useCase: this.useCase,
+            parent: this.parentUseCase
         });
+        this._isExecuted = true;
     }
 
     /**
@@ -78,7 +103,7 @@ export default class UseCaseExecutor {
      * @param {function(useCase: UseCase)} handler
      */
     onDidExecuteEachUseCase(handler) {
-        const releaseHandler = this.parentDispatcher.onDispatch(function onDidExecuteEachUseCaseInUseCaseExecutor(payload){
+        const releaseHandler = this.parentDispatcher.onDispatch(function onDidExecuteEachUseCaseInUseCaseExecutor(payload) {
             if (payload.type === ActionTypes.ON_DID_EXECUTE_EACH_USECASE) {
                 handler(payload.useCase);
             }
@@ -95,6 +120,10 @@ export default class UseCaseExecutor {
     execute(...args) {
         this.willExecute(args);
         const result = this.useCase.execute(...args);
+        // Sync call didExecute
+        if (!isPromise(result)) {
+            this.didExecute(result);
+        }
         return Promise.resolve(result).then((result) => {
             this.didExecute(result);
             this.release();

--- a/src/index.js
+++ b/src/index.js
@@ -3,11 +3,13 @@
 import Dispatcher from "./Dispatcher";
 import Store from "./Store";
 import StoreGroup from "./UILayer/StoreGroup";
+import QueuedStoreGroup from "./UILayer/QueuedStoreGroup";
 import UseCase from "./UseCase";
 import Context from "./Context";
 // re-export
 module.exports.Dispatcher = Dispatcher;
 module.exports.Store = Store;
 module.exports.StoreGroup = StoreGroup;
+module.exports.QueuedStoreGroup = QueuedStoreGroup;
 module.exports.UseCase = UseCase;
 module.exports.Context = Context;

--- a/test/QueuedStoreGroup-test.js
+++ b/test/QueuedStoreGroup-test.js
@@ -1,0 +1,301 @@
+// LICENSE : MIT
+"use strict";
+const assert = require("power-assert");
+import Store from "../src/Store";
+import QueuedStoreGroup from "../src/UILayer/QueuedStoreGroup";
+import createEchoStore from "./helper/EchoStore";
+import UseCase from "../src/UseCase";
+import Context from "../src/Context";
+import Dispatcher from "../src/Dispatcher";
+const createAsyncChangeStoreUseCase = (store) => {
+    class ChangeTheStoreUseCase extends UseCase {
+        execute() {
+            return Promise.resolve().then(() => {
+                store.emitChange();
+            });
+        }
+    }
+    return new ChangeTheStoreUseCase()
+};
+const createChangeStoreUseCase = (store) => {
+    class ChangeTheStoreUseCase extends UseCase {
+        execute() {
+            store.emitChange();
+        }
+    }
+    return new ChangeTheStoreUseCase()
+};
+describe("QueuedStoreGroup", function() {
+    describe("#onChange", function() {
+        context("when StoreGroup#emitChange()", function() {
+            it("should be called by sync", function() {
+                const store = createEchoStore({name: "AStore"});
+                const storeGroup = new QueuedStoreGroup([store]);
+                let isCalled = false;
+                // then
+                storeGroup.onChange(() => {
+                    isCalled = true;
+                });
+                // when
+                storeGroup.emitChange();
+                assert(isCalled);
+            });
+        });
+        // sync
+        context("when SyncUseCase change the store", function() {
+            it("should be called by sync", function() {
+                const store = createEchoStore({name: "AStore"});
+                const storeGroup = new QueuedStoreGroup([store]);
+                let isCalled = false;
+                // then
+                storeGroup.onChange(() => {
+                    isCalled = true;
+                });
+                // when
+                const useCase = createChangeStoreUseCase(store);
+                const context = new Context({
+                    dispatcher: new Dispatcher(),
+                    store: storeGroup
+                });
+                context.useCase(useCase).execute();
+                // sync!!!
+                assert(isCalled);
+            });
+        });
+        // async
+        context("when ASyncUseCase change the store", function() {
+            it("should be called by async", function() {
+                const store = createEchoStore({name: "AStore"});
+                const storeGroup = new QueuedStoreGroup([store]);
+                let isCalled = false;
+                storeGroup.onChange(() => {
+                    isCalled = true;
+                });
+                // when
+                const asyncUseCase = createAsyncChangeStoreUseCase(store);
+                const context = new Context({
+                    dispatcher: new Dispatcher(),
+                    store: storeGroup
+                });
+                // then
+                const promise = context.useCase(asyncUseCase).execute().then(() => {
+                    assert(isCalled);
+                });
+                // not yet change
+                assert(isCalled === false);
+                return promise
+            });
+        });
+        context("when UseCase is nesting", function() {
+            it("should be called only once", function() {
+                const aStore = createEchoStore({name: "AStore"});
+                const bStore = createEchoStore({name: "BStore"});
+                const storeGroup = new QueuedStoreGroup([aStore, bStore]);
+                let onChangeCounter = 0;
+                storeGroup.onChange((changedStores) => {
+                    assert.equal(changedStores.length, 2);
+                    assert.deepEqual(changedStores, [aStore, bStore]);
+                    onChangeCounter += 1;
+                });
+                // when
+                const changeBUseCase = createAsyncChangeStoreUseCase(bStore);
+                class ChangeAAndBUseCase extends UseCase {
+                    execute() {
+                        aStore.emitChange();
+                        return this.context.useCase(changeBUseCase).execute();
+                    }
+                }
+                const context = new Context({
+                    dispatcher: new Dispatcher(),
+                    store: storeGroup
+                });
+                // then
+                const useCase = new ChangeAAndBUseCase();
+                return context.useCase(useCase).execute().then(() => {
+                    assert.equal(onChangeCounter, 1);
+                });
+            });
+        });
+        context("when UseCase is failing", function() {
+            it("should be called before UseCase is executed", function() {
+                const aStore = createEchoStore({name: "AStore"});
+                const storeGroup = new QueuedStoreGroup([aStore]);
+                let onChangeCounter = 0;
+                storeGroup.onChange((changedStores) => {
+                    assert.equal(changedStores.length, 1);
+                    assert.deepEqual(changedStores, [aStore]);
+                    onChangeCounter += 1;
+                });
+                // when
+                class FailUseCase extends UseCase {
+                    execute() {
+                        aStore.emitChange();
+                        return Promise.reject(new Error("emit change but fail usecase"));
+                    }
+                }
+                const context = new Context({
+                    dispatcher: new Dispatcher(),
+                    store: storeGroup
+                });
+                // then
+                const useCase = new FailUseCase();
+                return context.useCase(useCase).execute().catch(() => {
+                    assert.equal(onChangeCounter, 1);
+                });
+            });
+        });
+        context("WhiteBox testing", function() {
+            it("should thin out change events at once", function() {
+                const aStore = createEchoStore({name: "AStore"});
+                const bStore = createEchoStore({name: "BStore"});
+                const storeGroup = new QueuedStoreGroup([aStore, bStore]);
+                class ChangeABUseCase extends UseCase {
+                    execute() {
+                        aStore.emitChange();
+                        aStore.emitChange();
+                        bStore.emitChange();
+                    }
+                }
+                const useCase = new ChangeABUseCase();
+                const context = new Context({
+                    dispatcher: new Dispatcher(),
+                    store: storeGroup
+                });
+                // then - called change handler a one-time
+                storeGroup.onChange((changedStores) => {
+                    assert.equal(changedStores.length, 2);
+                });
+                // when
+                return context.useCase(useCase).execute().then(() => {
+                    assert.equal(storeGroup.currentChangingStores.length, 2);
+                    // then next emit change
+                    aStore.emitChange();
+                    // reset changing stores
+                    assert.equal(storeGroup.currentChangingStores.length, 1);
+                });
+            });
+        })
+    });
+    describe("#getState", function() {
+        it("should return a single state object", function() {
+            class AStore extends Store {
+                getState() {
+                    return {a: "a value"};
+                }
+            }
+            class BStore extends Store {
+                getState() {
+                    return {b: "b value"};
+                }
+            }
+            const aStore = new AStore();
+            const bStore = new BStore();
+            const storeGroup = new QueuedStoreGroup([aStore, bStore]);
+            // when - a,b emit change at same time
+            const state = storeGroup.getState();
+            // then - return a single state object that contain each store and merge
+            assert.deepEqual(state, {
+                a: "a value",
+                b: "b value"
+            });
+        });
+        context("when getState() return State object", function() {
+            it("should return a single state has {<key>: state} of return Store#getState", function() {
+                class AState {
+                }
+                class AStore extends Store {
+                    getState() {
+                        return {
+                            aState: new AState()
+                        };
+                    }
+                }
+                class BState {
+                }
+                class BStore extends Store {
+                    getState() {
+                        return {
+                            bState: new BState()
+                        };
+                    }
+                }
+                const aStore = new AStore();
+                const bStore = new BStore();
+                const storeGroup = new QueuedStoreGroup([aStore, bStore]);
+                // when - a,b emit change at same time
+                const state = storeGroup.getState();
+                // then - return a single state object that contain each store and merge
+                const keys = Object.keys(state);
+                assert(keys.indexOf("aState") !== -1);
+                assert(state["aState"] instanceof AState);
+                assert(state["bState"] instanceof BState);
+            });
+        });
+
+        context("when a store emit change", function() {
+            it("should returned state replace with new getState() result", function() {
+                let aCalledCount = 0;
+                let bCalledCount = 0;
+                class AState {
+                    constructor({count}) {
+                        this.count = count;
+                    }
+                }
+                // then - emitChange => countup
+                class AStore extends Store {
+                    getState() {
+                        aCalledCount = aCalledCount + 1;
+                        return {
+                            AState: new AState({count: aCalledCount})
+                        }
+                    }
+                }
+                class BState {
+                    constructor({count}) {
+                        this.count = count;
+                    }
+                }
+                class BStore extends Store {
+                    getState() {
+                        bCalledCount = bCalledCount + 1;
+                        return {
+                            BState: new BState({count: bCalledCount})
+                        };
+                    }
+                }
+                const aStore = new AStore();
+                const bStore = new BStore();
+                const storeGroup = new QueuedStoreGroup([aStore, bStore]);
+                assert.equal(storeGroup.getState()["AState"].count, 1);
+                assert.equal(storeGroup.getState()["BState"].count, 1);
+                assert.equal(storeGroup.getState()["AState"].count, 1);
+                assert.equal(storeGroup.getState()["BState"].count, 1);
+                // when
+                const useCase = createChangeStoreUseCase(aStore);
+                const context = new Context({
+                    dispatcher: new Dispatcher(),
+                    store: storeGroup
+                });
+                return context.useCase(useCase).execute().then(() => {
+                    assert.equal(storeGroup.getState()["AState"].count, 2);
+                    assert.equal(storeGroup.getState()["BState"].count, 1);
+                });
+            });
+        });
+    });
+    describe("#release", function() {
+        it("release onChange handler", function() {
+            const aStore = createEchoStore({name: "AStore"});
+            const bStore = createEchoStore({name: "BStore"});
+            const storeGroup = new QueuedStoreGroup([aStore, bStore]);
+            // then - called change handler a one-time
+            let isCalled = false;
+            storeGroup.onChange(() => {
+                isCalled = true;
+            });
+            storeGroup.release();
+            storeGroup.emitChange();
+            assert(!isCalled);
+        });
+    });
+});

--- a/test/QueuedStoreGroup-test.js
+++ b/test/QueuedStoreGroup-test.js
@@ -41,6 +41,30 @@ describe("QueuedStoreGroup", function() {
                 assert(isCalled);
             });
         });
+        context("when UseCase never change any store", function() {
+            it("should not be called", function() {
+                const store = createEchoStore({name: "AStore"});
+                const storeGroup = new QueuedStoreGroup([store]);
+                let isCalled = false;
+                // then
+                storeGroup.onChange(() => {
+                    isCalled = true;
+                });
+                // when
+                const useCase = new class NopeUseCase extends UseCase {
+                    execute() {
+                        // not change any store
+                    }
+                };
+                const context = new Context({
+                    dispatcher: new Dispatcher(),
+                    store: storeGroup
+                });
+                return context.useCase(useCase).execute().then(() => {
+                    assert(isCalled === false);
+                });
+            });
+        });
         // sync
         context("when SyncUseCase change the store", function() {
             it("should be called by sync", function() {

--- a/test/QueuedStoreGroup-test.js
+++ b/test/QueuedStoreGroup-test.js
@@ -141,7 +141,7 @@ describe("QueuedStoreGroup", function() {
             });
         });
         context("when UseCase is failing", function() {
-            it("should be called before UseCase is executed", function() {
+            it("should be called", function() {
                 const aStore = createEchoStore({name: "AStore"});
                 const storeGroup = new QueuedStoreGroup([aStore]);
                 let onChangeCounter = 0;
@@ -154,7 +154,7 @@ describe("QueuedStoreGroup", function() {
                 class FailUseCase extends UseCase {
                     execute() {
                         aStore.emitChange();
-                        return Promise.reject(new Error("emit change but fail usecase"));
+                        return Promise.reject(new Error("emit change but fail UseCase"));
                     }
                 }
                 const context = new Context({

--- a/test/StoreGroup-test.js
+++ b/test/StoreGroup-test.js
@@ -5,15 +5,12 @@ import Store from "../src/Store";
 import StoreGroup from "../src/UILayer/StoreGroup";
 import createEchoStore from "./helper/EchoStore";
 
-describe("StoreGroup", function () {
-    describe("#onChange", function () {
-        it("should async called onChange ", function (done) {
+describe("StoreGroup", function() {
+    describe("#onChange", function() {
+        it("should async called onChange ", function(done) {
             const aStore = createEchoStore({name: "AStore"});
             const bStore = createEchoStore({name: "BStore"});
             const storeGroup = new StoreGroup([aStore, bStore]);
-            // when - a,b emit change at same time
-            aStore.emitChange();
-            bStore.emitChange();
             // Should be failure, if emit -> onChange **sync**.
             // But it is called async
             // then - called change handler a one-time
@@ -21,8 +18,11 @@ describe("StoreGroup", function () {
                 assert.equal(changedStores.length, 2);
                 done();
             });
+            // when - a,b emit change at same time
+            aStore.emitChange();
+            bStore.emitChange();
         });
-        it("should async called onChange after 2nd", function (done) {
+        it("should async called onChange after 2nd", function(done) {
             // it should work cache temporary.
             // test _prunePreviousCache
             const aStore = createEchoStore({name: "AStore"});
@@ -59,7 +59,7 @@ describe("StoreGroup", function () {
                 })
             })
         });
-        it("should thin out change events at once", function (done) {
+        it("should thin out change events at once", function(done) {
             const aStore = createEchoStore({name: "AStore"});
             const bStore = createEchoStore({name: "BStore"});
             const storeGroup = new StoreGroup([aStore, bStore]);
@@ -74,8 +74,8 @@ describe("StoreGroup", function () {
             bStore.emitChange();
         });
     });
-    describe("#getState", function () {
-        it("should return a single state object", function () {
+    describe("#getState", function() {
+        it("should return a single state object", function() {
             class AStore extends Store {
                 getState() {
                     return {a: "a value"};
@@ -97,8 +97,8 @@ describe("StoreGroup", function () {
                 b: "b value"
             });
         });
-        context("when getState() return State object", function () {
-            it("should return a single state has {<key>: state} of return Store#getState", function () {
+        context("when getState() return State object", function() {
+            it("should return a single state has {<key>: state} of return Store#getState", function() {
                 class AState {
                 }
                 class AStore extends Store {
@@ -130,8 +130,8 @@ describe("StoreGroup", function () {
             });
         });
 
-        context("when a store emit change", function () {
-            it("should returned state replace with new getState() result", function (done) {
+        context("when a store emit change", function() {
+            it("should returned state replace with new getState() result", function(done) {
                 let aCalledCount = 0;
                 let bCalledCount = 0;
                 class AState {
@@ -179,8 +179,8 @@ describe("StoreGroup", function () {
             });
         });
     });
-    describe("#release", function () {
-        it("release onChange handler", function () {
+    describe("#release", function() {
+        it("release onChange handler", function() {
             const aStore = createEchoStore({name: "AStore"});
             const bStore = createEchoStore({name: "BStore"});
             const storeGroup = new StoreGroup([aStore, bStore]);

--- a/test/UseCaseExecutor-test.js
+++ b/test/UseCaseExecutor-test.js
@@ -4,9 +4,9 @@ const assert = require("power-assert");
 import UseCaseExecutor from "../src/UseCaseExecutor";
 import UseCase from "../src/UseCase";
 import Dispatcher from "../src/Dispatcher";
-describe("UseCaseExecutor", function () {
-    context("when UseCase is successful completion", function () {
-        it("dispatch will -> did", function () {
+describe("UseCaseExecutor", function() {
+    context("when UseCase is successful completion", function() {
+        it("dispatch will -> did", function() {
             // given
             const expectedPayload = {
                 type: "SyncUseCase",
@@ -20,7 +20,10 @@ describe("UseCaseExecutor", function () {
             }
             const callStack = [];
             const expectedCallStack = [1, 2, 3];
-            const executor = new UseCaseExecutor(new SyncUseCase(), dispatcher);
+            const executor = new UseCaseExecutor({
+                useCase: new SyncUseCase(),
+                dispatcher
+            });
             // then
             executor.onWillExecuteEachUseCase(() => {
                 callStack.push(1);
@@ -39,9 +42,9 @@ describe("UseCaseExecutor", function () {
             });
         });
     });
-    describe("#execute", function () {
-        context("when UseCase is sync", function () {
-            it("execute is called", function (done) {
+    describe("#execute", function() {
+        context("when UseCase is sync", function() {
+            it("execute is called", function(done) {
                 // given
                 const expectedPayload = {
                     type: "SyncUseCase",
@@ -64,12 +67,15 @@ describe("UseCaseExecutor", function () {
                     }
                 });
                 // when
-                const executor = new UseCaseExecutor(new SyncUseCase(), dispatcher);
+                const executor = new UseCaseExecutor({
+                    useCase: new SyncUseCase(),
+                    dispatcher
+                });
                 executor.execute(expectedPayload);// 1
             });
         });
-        context("when UseCase is async", function () {
-            it("execute is called", function (done) {
+        context("when UseCase is async", function() {
+            it("execute is called", function(done) {
                 // given
                 const expectedPayload = {
                     type: "SyncUseCase",
@@ -95,7 +101,10 @@ describe("UseCaseExecutor", function () {
                     }
                 });
                 // when
-                const executor = new UseCaseExecutor(new AsyncUseCase(), dispatcher);
+                const executor = new UseCaseExecutor({
+                    useCase: new AsyncUseCase(),
+                    dispatcher
+                });
                 executor.onDidExecuteEachUseCase(useCase => {
                     if (useCase instanceof AsyncUseCase) {
                         assert(isCalledUseCase);


### PR DESCRIPTION
It work as Sync/Async store group.
This commit include some changes:

- When UseCase's result is not promise, call immediately `didExecute`
- UseCaseExecutor  has `parentUseCase`
- Root UseCaseExecutor has not `parentUseCase`
  - It similar with prototype chain(`Object.getPrototypeOf(Object.prototype); //=> null`)

## Difference between StoreGroup and QueuedStoreGroup

- QueuedStoreGroup not dependant on async function like `setTimeout`.
- QueuedStoreGroup work as Sync or Async.
- QueuedStoreGroup dependant on execution of UseCase.
- StoreGroup focus on changing of store-self.
- QueuedStoreGroup focus on execution of UseCase.

## Timing

![wavedrom editor 2016-08-04 09-51-14](https://cloud.githubusercontent.com/assets/19714/17386804/06ebd7e8-5a29-11e6-9278-73177007a408.png)


```
{ signal: [
  ['Store',
   { name: "A",
    wave: '0...3..0....', data:["Change"]},
   { name: "B",
    wave: '0....3..0...', data:["Change"]},
  ],
  {},
  {
    name: "UseCase",
    wave: "0.20.......30.....", data:["will", "did"]
  },
  { name: 'QueuedStoreGroup',
    wave: '0..........3.0..', data:["onChange()"]
  },
   { name: 'StoreGroup',
    wave: '0.......3.0.....', data:["onChange()"]
  },
]}
// http://wavedrom.com/editor.html
````

## Limitation of QueuedStoreGroup

- QueuedStoreGroup not allow to change **stores** directly.
- Always change **stores** via execution of UseCase.