### PR TITLE
QueuedStoreGroup should call #onChange when UseCase#dispatch is called

### DIFF
--- a/src/Context.js
+++ b/src/Context.js
@@ -18,7 +18,7 @@ export default class Context {
 
     /**
      * @param {Dispatcher} dispatcher
-     * @param {StoreGroup|Store} store store is either Store or StoreGroup
+     * @param {QueuedStoreGroup|StoreGroup|Store} store store is either Store or StoreGroup
      * @public
      */
     constructor({dispatcher, store}) {
@@ -96,7 +96,7 @@ export default class Context {
      * This `onDispatch` is not called at built-in event. It is filtered by Context.
      * If you want to *All* dispatched event and use listen directly your `dispatcher` object.
      * In other word, listen the dispatcher of `new Context({dispatcher})`.
-     * @param handler
+     * @param {function(payload: DispatcherPayload)} handler
      * @returns {Function}
      * @public
      */

--- a/src/UILayer/QueuedStoreGroup.js
+++ b/src/UILayer/QueuedStoreGroup.js
@@ -201,6 +201,9 @@ StoreGroup#getState()["StateName"]; // state
     }
 
     emitChange() {
+        if(!this._isAnyOneStoreChanged) {
+            return;
+        }
         const changingStores = this._currentChangingStores.slice();
         // release ownership  of changingStores from StoreGroup
         // transfer ownership of changingStores to other

--- a/src/UILayer/QueuedStoreGroup.js
+++ b/src/UILayer/QueuedStoreGroup.js
@@ -91,7 +91,7 @@ export default class QueuedStoreGroup extends Dispatcher {
         // `this` can catch the events of dispatchers
         // Because context delegate dispatched events to **this**
         const didExecutedUseCase = (payload) => {
-            // call handler, if payload's type is not built-in event.
+            // check stores, if payload's type is not built-in event.
             // It means that `onDispatch` is called when dispatching user event.
             if (ActionTypes[payload.type] === undefined) {
                 if (this.hasChangingStore) {

--- a/src/UILayer/StoreGroupValidator.js
+++ b/src/UILayer/StoreGroupValidator.js
@@ -30,7 +30,7 @@ StoreGroup merge values of store*s*.`);
     /**
      * validate the instance is StoreGroup-like object
      * {@link Context} treat StoreGroup like object as StoreGroup.
-     * @param {*} storeGroup
+     * @param {*|StoreGroup|Store} storeGroup
      */
     static validateInstance(storeGroup) {
         assert(storeGroup !== undefined, "store should not be undefined");

--- a/src/UILayer/StoreGroupValidator.js
+++ b/src/UILayer/StoreGroupValidator.js
@@ -30,7 +30,7 @@ StoreGroup merge values of store*s*.`);
     /**
      * validate the instance is StoreGroup-like object
      * {@link Context} treat StoreGroup like object as StoreGroup.
-     * @param {StoreGroup|Object} storeGroup
+     * @param {*} storeGroup
      */
     static validateInstance(storeGroup) {
         assert(storeGroup !== undefined, "store should not be undefined");

--- a/test/QueuedStoreGroup-test.js
+++ b/test/QueuedStoreGroup-test.js
@@ -28,7 +28,7 @@ const createChangeStoreUseCase = (store) => {
 describe("QueuedStoreGroup", function() {
     describe("#onChange", function() {
         context("when StoreGroup#emitChange()", function() {
-            context("anyone store is changed", function() {
+            context("some store is changed", function() {
                 it("should be called by sync", function() {
                     const store = createEchoStore({name: "AStore"});
                     const storeGroup = new QueuedStoreGroup([store]);
@@ -321,6 +321,32 @@ describe("QueuedStoreGroup", function() {
                 const useCase = new FailUseCase();
                 return context.useCase(useCase).execute().catch(() => {
                     assert.equal(onChangeCounter, 1);
+                });
+            });
+        });
+        context("when UseCase call `throwError(){", function() {
+            it("should be called", function() {
+                const store = createEchoStore({name: "AStore"});
+                const storeGroup = new QueuedStoreGroup([store]);
+                let isCalled = false;
+                // then
+                storeGroup.onChange(() => {
+                    isCalled = true;
+                });
+                // when
+                const useCase = new class ThrowErrorUseCase extends UseCase {
+                    execute() {
+                        store.emitChange();
+                        // dispatch event
+                        this.throwError(new Error("error message"));
+                    }
+                };
+                const context = new Context({
+                    dispatcher: new Dispatcher(),
+                    store: storeGroup
+                });
+                return context.useCase(useCase).execute().then(() => {
+                    assert(isCalled);
                 });
             });
         });


### PR DESCRIPTION
Currently, QueuedStoreGroup should not call `QueuedStoreGroup#emitChange()` when UseCase#dispatch is called.

#40 support only `didExecutedUseCase` events.
It is unexpected behavior for user.

We should support `UseCase#dispatch` events.

## Algorithm

QueuedStoreGroup check changed stores and `QueuedStoreGroup#emitChange()` on following case:

- when emit root `didExecutedUseCase` events
      - when emit every `didExecutedUseCase` events if `{ asap : true}` option is enabled
- when emit `UseCase#dispatch` events
      - every `type`

