### PR TITLE
fix(QueuedStoreGroup): remove state cache from QueuedStoreGroup

### DIFF
--- a/src/UILayer/QueuedStoreGroup.js
+++ b/src/UILayer/QueuedStoreGroup.js
@@ -37,6 +37,9 @@ const defaultOptions = {
  * ## Note
  * - QueuedStoreGroup not allow to change **stores** directly.
  * - Always change **stores** via execution of UseCase.
+ * - QueuedStoreGroup has not cache state.
+ *  - Cache system should be in your Store.
+ *
  * @public
  */
 export default class QueuedStoreGroup extends Dispatcher {
@@ -123,10 +126,6 @@ export default class QueuedStoreGroup extends Dispatcher {
              It is for Use Store's getState(prevState) implementation.
              */
             const prevState = this._stateCache.get(store);
-            // if the `store` is changed in previous
-            if (prevState && this.currentChangingStores.indexOf(store) === -1) {
-                return prevState;
-            }
             const nextState = store.getState(prevState);
             assert(typeof nextState == "object", `${store}: ${store.name}.getState() should return Object.
 e.g.)

--- a/src/UILayer/StoreGroup.js
+++ b/src/UILayer/StoreGroup.js
@@ -78,7 +78,8 @@ export default class StoreGroup extends Dispatcher {
              }
              */
             const prevState = this._stateCache.get(store);
-            // if the `store` is changed in previous
+            // if the `store` is not changed in previous, return cached state
+            // Otherwise, the store is changed return new Store#getState()
             if (prevState && this._previousChangingStores.indexOf(store) === -1) {
                 return prevState;
             }

--- a/test/QueuedStoreGroup-test.js
+++ b/test/QueuedStoreGroup-test.js
@@ -290,57 +290,6 @@ describe("QueuedStoreGroup", function() {
                 assert(state["bState"] instanceof BState);
             });
         });
-
-        context("when a store emit change", function() {
-            it("should returned state replace with new getState() result", function() {
-                let aCalledCount = 0;
-                let bCalledCount = 0;
-                class AState {
-                    constructor({count}) {
-                        this.count = count;
-                    }
-                }
-                // then - emitChange => countup
-                class AStore extends Store {
-                    getState() {
-                        aCalledCount = aCalledCount + 1;
-                        return {
-                            AState: new AState({count: aCalledCount})
-                        }
-                    }
-                }
-                class BState {
-                    constructor({count}) {
-                        this.count = count;
-                    }
-                }
-                class BStore extends Store {
-                    getState() {
-                        bCalledCount = bCalledCount + 1;
-                        return {
-                            BState: new BState({count: bCalledCount})
-                        };
-                    }
-                }
-                const aStore = new AStore();
-                const bStore = new BStore();
-                const storeGroup = new QueuedStoreGroup([aStore, bStore]);
-                assert.equal(storeGroup.getState()["AState"].count, 1);
-                assert.equal(storeGroup.getState()["BState"].count, 1);
-                assert.equal(storeGroup.getState()["AState"].count, 1);
-                assert.equal(storeGroup.getState()["BState"].count, 1);
-                // when
-                const useCase = createChangeStoreUseCase(aStore);
-                const context = new Context({
-                    dispatcher: new Dispatcher(),
-                    store: storeGroup
-                });
-                return context.useCase(useCase).execute().then(() => {
-                    assert.equal(storeGroup.getState()["AState"].count, 2);
-                    assert.equal(storeGroup.getState()["BState"].count, 1);
-                });
-            });
-        });
     });
     describe("#release", function() {
         it("release onChange handler", function() {


### PR DESCRIPTION
- QueuedStoreGroup has not cache state.
   - Cache is very buggy in StoreGroup
   - Because QueuedStoreGroup reaction to events of UseCase instead of changes of store.
- Cache system should be in your Store.