### PR TITLE
Breaking Change: add Context#onCompleteExecuteEachUseCase

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,8 +67,6 @@
     "zuul": "^3.10.1"
   },
   "dependencies": {
-    "babel-preset-jsdoc-to-assert": "^3.0.1",
-    "is-promise": "^2.1.0",
     "lru-cache": "^4.0.1",
     "object-assign": "^4.1.0"
   }

--- a/src/Context.js
+++ b/src/Context.js
@@ -9,8 +9,10 @@ import StoreGroupValidator from "./UILayer/StoreGroupValidator";
  * The use should use on* handler method instead of it
  */
 export const ActionTypes = {
+    // will -> execute -> did -> (promise resolved) -> complete
     ON_WILL_EXECUTE_EACH_USECASE: "ON_WILL_EXECUTE_EACH_USECASE",
     ON_DID_EXECUTE_EACH_USECASE: "ON_DID_EXECUTE_EACH_USECASE",
+    ON_COMPLETE_EACH_USECASE: "ON_COMPLETE_EACH_USECASE",
     ON_ERROR: "ON_ERROR"
 };
 
@@ -113,7 +115,7 @@ export default class Context {
     }
 
     /**
-     * called the {@link handler} with useCase when the useCase is done.
+     * called the `handler` with useCase when the useCase is executed..
      * @param {function(useCase: UseCase)} handler
      * @public
      */
@@ -126,6 +128,23 @@ export default class Context {
         this._releaseHandlers.push(releaseHandler);
         return releaseHandler;
     }
+
+    /**
+     * called the `handler` with useCase when the useCase is completed.
+     * @param {function(useCase: UseCase)} handler
+     * @public
+     */
+    onCompleteExecuteEachUseCase(handler) {
+        const releaseHandler = this._dispatcher.onDispatch(payload => {
+            if (payload.type === ActionTypes.ON_COMPLETE_EACH_USECASE) {
+                handler(payload.useCase);
+            }
+        });
+        this._releaseHandlers.push(releaseHandler);
+        return releaseHandler;
+    }
+
+
 
     /**
      * called the `errorHandler` with error when error is occurred.

--- a/src/UILayer/QueuedStoreGroup.js
+++ b/src/UILayer/QueuedStoreGroup.js
@@ -114,6 +114,15 @@ export default class QueuedStoreGroup extends Dispatcher {
                 if (this.hasChangingStore) {
                     this.emitChange();
                 }
+            } else if (payload.type === ActionTypes.ON_COMPLETE_EACH_USECASE) {
+                const parent = payload.parent;
+                // when {asap: false}, emitChange when root useCase is executed
+                if (!asap && parent) {
+                    return;
+                }
+                if (this.hasChangingStore) {
+                    this.emitChange();
+                }
             }
         };
         const unListenOnDispatch = this.onDispatch(tryToEmitChange);

--- a/test/UseCaseExecutor-test.js
+++ b/test/UseCaseExecutor-test.js
@@ -75,7 +75,7 @@ describe("UseCaseExecutor", function() {
             });
         });
         context("when UseCase is async", function() {
-            it("execute is called", function(done) {
+            it("execute is called", function() {
                 // given
                 const expectedPayload = {
                     type: "SyncUseCase",
@@ -93,6 +93,8 @@ describe("UseCaseExecutor", function() {
                 }
                 // then
                 let isCalledUseCase = false;
+                let isCalledDidExecuted = false;
+                let isCalledCompleted = false;
                 // 4
                 dispatcher.onDispatch(({type, value}) => {
                     if (type === expectedPayload.type) {
@@ -107,12 +109,20 @@ describe("UseCaseExecutor", function() {
                 });
                 executor.onDidExecuteEachUseCase(useCase => {
                     if (useCase instanceof AsyncUseCase) {
-                        assert(isCalledUseCase);
-                        done();
+                        isCalledDidExecuted = true;
+                    }
+                });
+                executor.onCompleteExecuteEachUseCase(useCase => {
+                    if (useCase instanceof AsyncUseCase) {
+                        isCalledCompleted = true;
                     }
                 });
                 // 1
-                executor.execute(expectedPayload);
+                return executor.execute(expectedPayload).then(() => {
+                    assert(isCalledUseCase);
+                    assert(isCalledDidExecuted);
+                    assert(isCalledCompleted);
+                });
             });
         });
     });


### PR DESCRIPTION
## Breaking Changes ⚡ 

- Separate `didExecuted` into "didExecuted" and "complete".
- "didExecuted" event always is called **sync**
- "complete" event always is called **async**

## Why? ❓ 

For improving stability.

The timing of dispatching "didExecuted" event is **sync** or **async**.
It is affected by _UseCase implementation_.

In the pull request,  We add "complete" event and defined the behavior to following.

- "didExecuted" event always is called **sync**
- "complete" event always is called **async**

## Work Flow of events

```js
context.useCase(useCaseA).execute();
```

1. **will execute** useCaseA
2. **did execute** useCaseA
3. if useCaseA reutrn `promise`
     - when the `promise` is resolved, **complete** useCaseA
     - when the `promise` is rejected, **complete** useCaseA
4. if useCaseA is not return any value
     - **complete** useCaseA

## Effect 😣 

The subscriber of `Context#onDidExecuteEachUseCase` is affected like [almin-logger](https://github.com/azu/almin-logger).