### PR TITLE
perf(StoreGroup): use lru-map-like insteadof lru-cache

### DIFF
--- a/example/counter/src/component/Counter.js
+++ b/example/counter/src/component/Counter.js
@@ -2,7 +2,7 @@
 "use strict";
 import React from "react"
 import IncrementalCounterUseCase from "../usecase/IncrementalCounterUseCase"
-import Context from "almin"
+import {Context} from "almin"
 import CounterState from "../store/CounterState"
 export default class CounterComponent extends React.Component {
     constructor(props) {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "zuul": "^3.10.1"
   },
   "dependencies": {
-    "lru-cache": "^4.0.1",
+    "lru-map-like": "^1.0.1",
     "object-assign": "^4.1.0"
   }
 }

--- a/src/Dispatcher.js
+++ b/src/Dispatcher.js
@@ -68,8 +68,10 @@ export default class Dispatcher extends EventEmitter {
      * @public
      */
     dispatch(payload) {
-        assert(payload !== undefined && payload !== null, "payload should not null or undefined");
-        assert(typeof payload.type !== "undefined", "payload's `type` should be required");
+        if (process.env.NODE_ENV !== "production") {
+            assert(payload !== undefined && payload !== null, "payload should not null or undefined");
+            assert(typeof payload.type !== "undefined", "payload's `type` should be required");
+        }
         this.emit(ON_DISPATCH, payload);
     }
 

--- a/src/Store.js
+++ b/src/Store.js
@@ -1,6 +1,5 @@
 // LICENSE : MIT
 "use strict";
-const assert = require("assert");
 import {ActionTypes} from "./Context";
 import Dispatcher from "./Dispatcher";
 const STATE_CHANGE_EVENT = "STATE_CHANGE_EVENT";

--- a/src/UILayer/QueuedStoreGroup.js
+++ b/src/UILayer/QueuedStoreGroup.js
@@ -161,7 +161,8 @@ export default class QueuedStoreGroup extends Dispatcher {
              */
             const prevState = this._stateCache.get(store);
             const nextState = store.getState(prevState);
-            assert(typeof nextState == "object", `${store}: ${store.name}.getState() should return Object.
+            if (process.env.NODE_ENV !== "production") {
+                assert(typeof nextState == "object", `${store}: ${store.name}.getState() should return Object.
 e.g.)
 
  class ExampleStore extends Store {
@@ -177,6 +178,7 @@ Then, use can access by StateName.
 StoreGroup#getState()["StateName"]; // state
 
 `);
+            }
             this._stateCache.set(store, nextState);
             return nextState;
         });

--- a/src/UILayer/QueuedStoreGroup.js
+++ b/src/UILayer/QueuedStoreGroup.js
@@ -3,8 +3,9 @@
 // polyfill Object.assign
 const ObjectAssign = require("object-assign");
 const assert = require("assert");
-const LRU = require("lru-cache");
+const LRU = require("lru-map-like");
 const CHANGE_STORE_GROUP = "CHANGE_STORE_GROUP";
+
 import Dispatcher from "./../Dispatcher";
 import Store from "./../Store";
 import StoreGroupValidator from "./StoreGroupValidator";
@@ -91,10 +92,7 @@ export default class QueuedStoreGroup extends Dispatcher {
          * @type {LRU}
          * @private
          */
-        this._stateCache = new LRU({
-            max: 100,
-            maxAge: 1000 * 60 * 60
-        });
+        this._stateCache = new LRU(100);
         // `this` can catch the events of dispatchers
         // Because context delegate dispatched events to **this**
         const tryToEmitChange = (payload) => {
@@ -255,7 +253,7 @@ StoreGroup#getState()["StateName"]; // state
     release() {
         this._releaseHandlers.forEach(releaseHandler => releaseHandler());
         this._releaseHandlers.length = 0;
-        this._stateCache.reset();
+        this._stateCache.clear();
     }
 
     /**

--- a/src/UILayer/StoreGroup.js
+++ b/src/UILayer/StoreGroup.js
@@ -4,7 +4,7 @@
 // polyfill Object.assign
 const ObjectAssign = require("object-assign");
 const assert = require("assert");
-const LRU = require("lru-cache");
+const LRU = require("lru-map-like");
 const CHANGE_STORE_GROUP = "CHANGE_STORE_GROUP";
 import Dispatcher from "./../Dispatcher";
 import Store from "./../Store";
@@ -53,10 +53,7 @@ export default class StoreGroup extends Dispatcher {
          * @type {LRU}
          * @private
          */
-        this._stateCache = new LRU({
-            max: 100,
-            maxAge: 1000 * 60 * 60
-        });
+        this._stateCache = new LRU(100);
     }
 
     /**
@@ -197,6 +194,6 @@ StoreGroup#getState()["StateName"]// state
     release() {
         this._releaseHandlers.forEach(releaseHandler => releaseHandler());
         this._releaseHandlers.length = 0;
-        this._stateCache.reset();
+        this._stateCache.clear();
     }
 }

--- a/src/UILayer/StoreGroup.js
+++ b/src/UILayer/StoreGroup.js
@@ -83,7 +83,8 @@ export default class StoreGroup extends Dispatcher {
                 return prevState;
             }
             const nextState = store.getState(prevState);
-            assert(typeof nextState == "object", `${store}: ${store.name}.getState() should return Object.
+            if (process.env.NODE_ENV !== "production") {
+                assert(typeof nextState == "object", `${store}: ${store.name}.getState() should return Object.
 e.g.)
 
  class ExampleStore extends Store {
@@ -99,6 +100,7 @@ Then, use can access by StateName.
 StoreGroup#getState()["StateName"]// state
 
 `);
+            }
             this._stateCache.set(store, nextState);
             return nextState;
         });

--- a/src/UseCase.js
+++ b/src/UseCase.js
@@ -1,6 +1,5 @@
 // LICENSE : MIT
 "use strict";
-const assert = require("assert");
 import Dispatcher from "./Dispatcher";
 import UseCaseContext from "./UseCaseContext";
 import {ActionTypes} from "./Context";

--- a/src/UseCaseContext.js
+++ b/src/UseCaseContext.js
@@ -20,7 +20,9 @@ export default class UseCaseContext {
      * @returns {UseCaseExecutor}
      */
     useCase(useCase) {
-        assert(useCase !== this.dispatcher, `the useCase(${useCase}) should not equal this useCase(${this.dispatcher})`);
+        if (process.env.NODE_ENV !== "production") {
+            assert(useCase !== this.dispatcher, `the useCase(${useCase}) should not equal this useCase(${this.dispatcher})`);
+        }
         return new UseCaseExecutor({
             useCase,
             parent: this.dispatcher,

--- a/src/UseCaseExecutor.js
+++ b/src/UseCaseExecutor.js
@@ -17,8 +17,10 @@ export default class UseCaseExecutor {
     }) {
         // execute and finish =>
         const useCaseName = useCase.name;
-        assert(typeof useCaseName === "string", "UseCase instance should have constructor.name " + useCase);
-        assert(typeof useCase.execute === "function", `UseCase instance should have #execute function: ${useCaseName}`);
+        if (process.env.NODE_ENV !== "production") {
+            assert(typeof useCaseName === "string", "UseCase instance should have constructor.name " + useCase);
+            assert(typeof useCase.execute === "function", `UseCase instance should have #execute function: ${useCaseName}`);
+        }
         /**
          * @type {string} useCase name
          */


### PR DESCRIPTION
[lru-map-like](https://github.com/azu/lru-map-like) is tiny implementation of LRU cache.

## Before

```
❯ package-size-analyzer -e lib/index.js
__ROOT__: 117.47 KB
  <self>: 54.36 KB
  assert: 11.43 KB
    <self>: 11.43 KB
  util: 15.4 KB
    <self>: 15.4 KB
  package-size-analyzer: 5.17 KB
    <self>: 0 B
    process: 5.17 KB
      <self>: 5.17 KB
  inherits: 672 B
    <self>: 672 B
  events: 8 KB
    <self>: 8 KB
  object-assign: 1.95 KB
    <self>: 1.95 KB
  lru-cache: 10.85 KB
    <self>: 10.85 KB
  pseudomap: 2.65 KB
    <self>: 2.65 KB
  yallist: 6.99 KB
    <self>: 6.99 KB
```

minify and gzip

```
❯ bundle-size ./lib/index.js -e development -e production
./lib/index.js

env          bundle  minify   gzip
--           123 kB  68.7 kB  19.6 kB
development  123 kB  68.7 kB  19.6 kB
production   123 kB  68.7 kB  19.6 kB
```

## After

```
❯ package-size-analyzer -e lib/index.js
__ROOT__: 109.82 KB
  <self>: 54.24 KB
  assert: 11.43 KB
    <self>: 11.43 KB
  util: 15.4 KB
    <self>: 15.4 KB
  package-size-analyzer: 5.17 KB
    <self>: 0 B
    process: 5.17 KB
      <self>: 5.17 KB
  inherits: 672 B
    <self>: 672 B
  events: 8 KB
    <self>: 8 KB
  object-assign: 1.95 KB
    <self>: 1.95 KB
  lru-map-like: 12.97 KB
    <self>: 7.84 KB
    map-like: 5.13 KB
      <self>: 5.13 KB
```

minify and gzip

```
❯ bundle-size ./lib/index.js -e development -e production
./lib/index.js

env          bundle  minify   gzip
--           115 kB  60.1 kB  16.4 kB
development  115 kB  59.6 kB  16.4 kB
production   115 kB  58.3 kB  16 kB
```

apply `unassert`

```
❯ bundle-size ./lib/index.js -e development -e production
./lib/index.js

env          bundle   minify   gzip
--           83.3 kB  43 kB    10.3 kB
development  77.6 kB  39.8 kB  9.23 kB
production   77.6 kB  39.8 kB  9.23 kB
```

close  #56