### PR TITLE
Introduce StoreLike interface

### DIFF
--- a/src/Context.ts
+++ b/src/Context.ts
@@ -8,6 +8,7 @@ import { DispatchedPayload } from "./Dispatcher";
 import DispatcherPayloadMeta from "./DispatcherPayloadMeta";
 import UseCase from "./UseCase";
 import Store from "./Store";
+import { StoreLike } from "./StoreLike";
 import UseCaseExecutor  from "./UseCaseExecutor";
 import StoreGroupValidator from "./UILayer/StoreGroupValidator";
 // payloads
@@ -20,7 +21,7 @@ import WillExecutedPayload, { isWillExecutedPayload } from "./payload/WillExecut
  */
 export default class Context {
     private _dispatcher: Dispatcher;
-    private _storeGroup: QueuedStoreGroup | StoreGroup | Store;
+    private _storeGroup: StoreLike & Dispatcher;
     private _releaseHandlers: Array<() => void>;
 
     /**
@@ -53,7 +54,7 @@ export default class Context {
      * @public
      */
     getState<T>(): T {
-        return (this._storeGroup as any).getState(); // TODO: remove casting `any`
+        return this._storeGroup.getState<T>();
     }
 
     /**
@@ -63,7 +64,7 @@ export default class Context {
      * @public
      */
     onChange(onChangeHandler: (hangingStores: Array<Store>) => void) {
-        return (this._storeGroup as any).onChange(onChangeHandler); // TODO: remove casting `any`
+        return this._storeGroup.onChange(onChangeHandler);
     }
 
     /**
@@ -172,8 +173,9 @@ export default class Context {
      * @public
      */
     release() {
-        if (typeof this._storeGroup === "function") {
-            (this._storeGroup as any).release(); // TODO: remove casting to any
+        const storeGroup = this._storeGroup;
+        if (!!storeGroup && typeof storeGroup.release === "function") {
+            storeGroup.release();
         }
         this._releaseHandlers.forEach(releaseHandler => releaseHandler());
         this._releaseHandlers.length = 0;

--- a/src/Store.ts
+++ b/src/Store.ts
@@ -4,6 +4,8 @@ import Dispatcher from "./Dispatcher";
 import DispatcherPayloadMeta from "./DispatcherPayloadMeta";
 import Payload from "./payload/Payload";
 import ErrorPayload from "./payload/ErrorPayload";
+import { StoreLike } from './StoreLike';
+
 const STATE_CHANGE_EVENT = "STATE_CHANGE_EVENT";
 /**
  * A UseCase `dispatch(payload)` and subscribers of the dispatcher are received the payload.
@@ -34,7 +36,7 @@ export let defaultStoreName = "<Anonymous-Store>";
  * Store class
  * @public
  */
-abstract class Store extends Dispatcher {
+abstract class Store extends Dispatcher implements StoreLike {
     /**
      * Debuggable name
      */
@@ -74,7 +76,7 @@ abstract class Store extends Dispatcher {
      *
      * FIXME: mark this as `abstract` property.
      */
-    getState<T>(_prevState: T): T {
+    getState<T>(_prevState?: T): T {
         throw new Error(this.name + " should be implemented Store#getState(): Object");
     }
 
@@ -108,7 +110,7 @@ abstract class Store extends Dispatcher {
      * @returns {Function} call the function and release handler
      * @public
      */
-    onChange(cb: Function): () => void {
+    onChange(cb: (hangingStores: Array<StoreLike>) => void): () => void {
         this.on(STATE_CHANGE_EVENT, cb);
         return this.removeListener.bind(this, STATE_CHANGE_EVENT, cb);
     }
@@ -118,7 +120,7 @@ abstract class Store extends Dispatcher {
      * @public
      */
     emitChange(): void {
-        this.emit(STATE_CHANGE_EVENT);
+        this.emit(STATE_CHANGE_EVENT, [this]);
     }
 }
 

--- a/src/StoreLike.ts
+++ b/src/StoreLike.ts
@@ -1,0 +1,7 @@
+// LICENSE : MIT
+
+export interface StoreLike {
+    getState<T>(): T;
+    onChange(onChangeHandler: (hangingStores: Array<StoreLike>) => void): void;
+    release?(): void;
+}

--- a/src/UILayer/QueuedStoreGroup.ts
+++ b/src/UILayer/QueuedStoreGroup.ts
@@ -10,6 +10,7 @@ import Dispatcher from "./../Dispatcher";
 import { DispatchedPayload } from "./../Dispatcher";
 import DispatcherPayloadMeta from "./../DispatcherPayloadMeta";
 import Store from "./../Store";
+import { StoreLike } from './../StoreLike';
 import StoreGroupValidator from "./StoreGroupValidator";
 import { isDidExecutedPayload } from "../payload/DidExecutedPayload";
 import { isErrorPayload } from "../payload/ErrorPayload";
@@ -64,7 +65,7 @@ export interface QueuedStoreGroupOption {
  *
  * @public
  */
-export default class QueuedStoreGroup extends Dispatcher {
+export default class QueuedStoreGroup extends Dispatcher implements StoreLike {
 
     private _releaseHandlers: Array<Function>;
     private _currentChangingStores: Array<Store>;

--- a/src/UILayer/StoreGroup.ts
+++ b/src/UILayer/StoreGroup.ts
@@ -9,6 +9,7 @@ import LRU from "./lru-map-like";
 import Dispatcher from "./../Dispatcher";
 import Store from "./../Store";
 import StoreGroupValidator from "./StoreGroupValidator";
+import { StoreLike } from './../StoreLike';
 import raq from "./raq";
 
 const CHANGE_STORE_GROUP = "CHANGE_STORE_GROUP";
@@ -20,7 +21,7 @@ const CHANGE_STORE_GROUP = "CHANGE_STORE_GROUP";
  * If you want to know all change events, and directly use `store.onChange()`.
  * @public
  */
-export default class StoreGroup extends Dispatcher {
+export default class StoreGroup extends Dispatcher implements StoreLike {
 
     private _releaseHandlers: Array<Function>;
     private _currentChangingStores: Array<Store>;


### PR DESCRIPTION
Motivation
----------

This introduce `StoreLike` interface to reduce `any` type from `Context.ts`.

Detailed Design
---------------

1. Introduce `StoreLike` interface which express that this objectjust
   behave as a "Store" object.
2. `Store`, `StoreGroup` and `QueuedStoreGroup` implements `StoreLike`.

Remained Tasks
--------------

- I did above steps conservatively. So we might have more chances to
  modify some signatures to use `StoreLike` instead of an actual classes ( https://github.com/almin/almin/issues/81 )