### PR TITLE
Remove babel-preset-jsdoc-to-assert from unit test

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,7 +5,6 @@
   "env": {
     "development": {
       "presets": [
-        "jsdoc-to-assert"
       ]
     }
   }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "add-text-to-markdown": "^1.0.2",
     "babel-cli": "^6.7.5",
     "babel-preset-es2015-ie": "^6.6.2",
-    "babel-preset-jsdoc-to-assert": "^4.0.0",
     "babel-preset-power-assert": "^1.0.0",
     "babel-register": "^6.7.2",
     "babelify": "^7.3.0",


### PR DESCRIPTION
- Fix https://github.com/almin/almin/issues/82
- This leaves `.babelrc` for https://github.com/almin/almin/issues/83