### PR TITLE
Remove ***Payload.Type static property

### DIFF
--- a/src/Store.ts
+++ b/src/Store.ts
@@ -3,7 +3,7 @@
 import Dispatcher from "./Dispatcher";
 import DispatcherPayloadMeta from "./DispatcherPayloadMeta";
 import Payload from "./payload/Payload";
-import ErrorPayload from "./payload/ErrorPayload";
+import { isErrorPayload } from "./payload/ErrorPayload";
 import { StoreLike } from './StoreLike';
 
 const STATE_CHANGE_EVENT = "STATE_CHANGE_EVENT";
@@ -97,7 +97,7 @@ abstract class Store extends Dispatcher implements StoreLike {
     onError(handler: (payload: Payload, meta: DispatcherPayloadMeta) => void): () => void {
         console.warn("Store#onError is deprecated. Please use Store#onDispatch.");
         return this.onDispatch((payload, meta) => {
-            if (payload.type === ErrorPayload.Type) {
+            if (isErrorPayload(payload)) {
                 handler(payload, meta);
             }
         });

--- a/src/payload/CompletedPayload.ts
+++ b/src/payload/CompletedPayload.ts
@@ -2,14 +2,13 @@
 "use strict";
 import Payload from "./Payload";
 
+/**
+ *  XXX: This is exported for an unit testing.
+ *  DO NOT USE THIS in your application.
+ */
 export const TYPE = "ALMIN__COMPLETED_EACH_USECASE__";
 
 export default class CompletedPayload extends Payload {
-
-    static get Type(): typeof TYPE {
-        return TYPE;
-    }
-
     /**
      * the value is returned by the useCase
      * Difference of DidExecutedPayload, the value always is resolved value.

--- a/src/payload/DidExecutedPayload.ts
+++ b/src/payload/DidExecutedPayload.ts
@@ -2,14 +2,13 @@
 "use strict";
 import Payload from "./Payload";
 
+/**
+ *  XXX: This is exported for an unit testing.
+ *  DO NOT USE THIS in your application.
+ */
 export const TYPE = "ALMIN__DID_EXECUTED_EACH_USECASE__";
 
 export default class DidExecutedPayload extends Payload {
-
-    static get Type(): typeof TYPE {
-        return TYPE;
-    }
-
     /**
      * the value is returned by the useCase
      * Maybe Promise or some value or undefined.

--- a/src/payload/ErrorPayload.ts
+++ b/src/payload/ErrorPayload.ts
@@ -2,17 +2,16 @@
 "use strict";
 import Payload from "./Payload";
 
+/**
+ *  XXX: This is exported for an unit testing.
+ *  DO NOT USE THIS in your application.
+ */
 export const TYPE = "ALMIN__ErrorPayload__";
 
 /**
  * This payload is executed
  */
 export default class ErrorPayload extends Payload {
-
-    static get Type(): typeof TYPE {
-        return TYPE;
-    }
-
     /**
      * the `error` in the UseCase
      */

--- a/src/payload/WillExecutedPayload.ts
+++ b/src/payload/WillExecutedPayload.ts
@@ -2,14 +2,13 @@
 "use strict";
 import Payload from "./Payload";
 
+/**
+ *  XXX: This is exported for an unit testing.
+ *  DO NOT USE THIS in your application.
+ */
 export const TYPE = "ALMIN__WILL_EXECUTED_EACH_USECASE__";
 
 export default class WillExecutedPayload extends Payload {
-
-    static get Type(): typeof TYPE {
-        return TYPE;
-    }
-
     /**
      * a array for argument of the useCase
      */

--- a/test/UseCase-test.js
+++ b/test/UseCase-test.js
@@ -6,7 +6,9 @@ import UseCase from "../lib/UseCase";
 import Dispatcher from "../lib/Dispatcher";
 import Store from "../lib/Store";
 import Context from "../lib/Context";
-import {WillExecutedPayload, DidExecutedPayload, CompletedPayload} from "../lib/index";
+import { TYPE as CompletedPayloadType } from '../lib/payload/CompletedPayload';
+import { TYPE as DidExecutedPayloadType } from '../lib/payload/DidExecutedPayload';
+import { TYPE as WillExecutedPayloadType } from '../lib/payload/WillExecutedPayload';
 import UseCaseContext from "../lib/UseCaseContext";
 
 describe("UseCase", function() {
@@ -60,9 +62,9 @@ describe("UseCase", function() {
             const bUseCase = new BUseCase();
             const callStack = [];
             const expectedCallStackOfAUseCase = [
-                WillExecutedPayload.Type,
-                DidExecutedPayload.Type,
-                CompletedPayload.Type
+                WillExecutedPayloadType,
+                DidExecutedPayloadType,
+                CompletedPayloadType
             ];
             const expectedCallStack = [
                 `${aUseCase.name}:will`,


### PR DESCRIPTION
- Breaking Change
- Fix https://github.com/almin/almin/issues/86
- To detect the type of `***Payload`, you should use `is***Payload()`.