### PR TITLE
Upgrade TypeScript 2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "textlint-rule-alex": "^1.0.1",
     "textlint-rule-common-misspellings": "^1.0.1",
     "textlint-rule-no-dead-link": "^3.0.1",
-    "typescript": "^2.1.6",
+    "typescript": "~2.2.1",
     "zuul": "^3.10.1"
   },
   "dependencies": {


### PR DESCRIPTION
- __I don't think this is a breaking change because we have not published TypeScript version yet__.
- I open this to aim to upgrade our baseline version because upgrading TypeScript would be a breaking change. Semantic versioning is the care of this problem and I think it's better to iterate its cycle rapidly.  But I (we?) would not like to upgrade it if there is no need.