### PR TITLE
feat(UseCase): add warning message "UseCase is already released"

### DIFF
--- a/docs/warnings/usecase-is-already-released.md
+++ b/docs/warnings/usecase-is-already-released.md
@@ -1,0 +1,68 @@
+# UseCase is already released
+
+There are a couple of likely reasons this warning could be appearing:
+
+- When child use-case is completed after parent use-case did completed
+
+**Bad**:
+
+
+```
+        P: Parent UseCase
+        C: Child UseCase
+
+                        P fin.   C fin.
+        |---------------|          |
+        P    |                     |
+             C---------------------|
+                              |
+                          C call dispatch()
+```
+
+```js
+class ChildUseCase extends UseCase {
+    execute() {
+        this.dispatch({ type: "ChildUseCase" });
+    }
+}
+class ParentUseCase extends UseCase {
+    execute() {
+        // ChildUseCase is independent from Parent
+        // But, ChildUseCase is executed from Parent
+        // This is programming error
+        setTimeout(() => {
+            this.context.useCase(new ChildUseCase()).execute();
+        }, 16);
+        return Promise.resolve();
+    }
+}
+```
+
+**Good**:
+
+```
+        P: Parent UseCase
+        C: Child UseCase
+
+                       C fin.       P fin.
+        |---------------|------------|
+        P    |          |
+             C----------
+                   |
+               C call dispatch()    
+
+ ```
+
+```js
+class ChildUseCase extends UseCase {
+    execute() {
+        this.dispatch({ type: "ChildUseCase" });
+    }
+}
+class ParentUseCase extends UseCase {
+    execute() {
+        // Parent wait for Child is completed
+        return this.context.useCase(new ChildUseCase()).execute();
+    }
+}
+```

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "npm-run-all": "^3.0.0",
     "power-assert": "^1.3.1",
     "rimraf": "^2.6.0",
+    "sinon": "^1.17.7",
     "textlint": "^7.1.0",
     "textlint-rule-alex": "^1.0.1",
     "textlint-rule-common-misspellings": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
   },
   "dependencies": {
     "lru-map-like": "^1.1.2",
+    "map-like": "^1.0.3",
     "object-assign": "^4.1.0"
   }
 }

--- a/src/UseCaseExecutor.ts
+++ b/src/UseCaseExecutor.ts
@@ -200,5 +200,20 @@ export class UseCaseExecutor {
     release(): void {
         this._releaseHandlers.forEach(releaseHandler => releaseHandler());
         this._releaseHandlers.length = 0;
+        if (process.env.NODE_ENV !== "production") {
+            this._addWarningNoMoreDispatch();
+        }
+    }
+
+    /**
+     * When child is completed after parent did completed, display warning warning message
+     * @private
+     */
+    private _addWarningNoMoreDispatch() {
+        this._useCase.onDispatch((payload, meta) => {
+            console.warn(`This UseCase(${this._useCase.name}) is already released.
+https://almin.js.org/docs/warnings/usecase-is-already-released.html
+`, payload, meta);
+        });
     }
 }

--- a/src/UseCaseInstanceMap.ts
+++ b/src/UseCaseInstanceMap.ts
@@ -1,0 +1,34 @@
+const MapLike = require("map-like");
+/*
+
+## UseCase instance lifecycle
+
+Each UseCase instance is managed by UseCaseInstanceMap.
+
+P: Parent UseCase
+C: Child UseCase
+Add: Add instance to UseCaseInstanceMap
+Delete: Remove instance from UseCaseInstanceMap
+
+    Add P         Delete P   Delete C
+    |---------------|          |
+    P    |                     |
+         C---------------------|
+      Add C              |
+                         |
+                     Point X
+
+If C refer to P on `Point X`, it will not be working correctly.
+Almin will say that `This P(parent UseCase) is already released!"
+
+See also https://almin.js.org/docs/warnings/usecase-is-already-released.html
+ */
+/**
+ * This Map maintains a mapping instance of UseCase
+ * A UseCase will execute and add it to this map.
+ * A UseCase was completed and remove it from this map.
+ *
+ * TODO: add d.ts to MapLike
+ * @type {Map}
+ */
+export const UseCaseInstanceMap = new MapLike();

--- a/test/QueuedStoreGroup-test.js
+++ b/test/QueuedStoreGroup-test.js
@@ -159,7 +159,6 @@ describe("QueuedStoreGroup", function() {
                         assert.equal(onChangeCounter, 2);
                     });
                 });
-
             });
             context("{ asap: false }", function() {
                 it("should be called only once", function() {
@@ -389,7 +388,7 @@ describe("QueuedStoreGroup", function() {
                 class ChangeTheStoreUseCase extends UseCase {
                     execute() {
                         store.emitChange();
-                        this.context.useCase(asyncUseCase).execute(); // 2
+                        return this.context.useCase(asyncUseCase).execute(); // 2
                     } // 1
                 }
                 const context = new Context({

--- a/test/UseCase-test.js
+++ b/test/UseCase-test.js
@@ -204,7 +204,7 @@ describe("UseCase", function() {
             afterEach(() => {
                 consoleWarnStub.restore();
             });
-            it("should delegate dispatch to parent -> dispatcher", function(done) {
+            it("should not delegate dispatch to parent -> dispatcher and show warning", function(done) {
                 const childPayload = {
                     type: "ChildUseCase"
                 };

--- a/test/UseCase-test.js
+++ b/test/UseCase-test.js
@@ -1,7 +1,7 @@
 // LICENSE : MIT
 "use strict";
 const assert = require("power-assert");
-
+const sinon = require("sinon");
 import { UseCase } from "../lib/UseCase";
 import { Dispatcher } from "../lib/Dispatcher";
 import { Store } from "../lib/Store";
@@ -43,6 +43,24 @@ describe("UseCase", function() {
             });
         });
     });
+    describe("#throwError", function() {
+        it("should dispatch thought onDispatch event", function(done) {
+            class TestUseCase extends UseCase {
+                execute() {
+                    this.throwError(new Error("error"));
+                }
+            }
+            const testUseCase = new TestUseCase();
+            // then
+            testUseCase.onDispatch(({type, error}) => {
+                assert(error instanceof Error);
+                done();
+            });
+            // when
+            testUseCase.execute();
+        });
+    });
+    // scenario
     context("when execute B UseCase in A UseCase", function() {
         it("should execute A:will -> B:will -> B:did -> A:did", function() {
             class BUseCase extends UseCase {
@@ -125,21 +143,109 @@ describe("UseCase", function() {
             }
         });
     });
-    describe("#throwError", function() {
-        it("should dispatch thought onDispatch event", function(done) {
-            class TestUseCase extends UseCase {
+    context("UseCase is nesting", function() {
+        /*
+            P: Parent UseCase
+            C: Child UseCase
+
+                           C fin.       P fin.
+            |---------------|------------|
+            P    |          |
+                 C----------
+
+         */
+        context("when child did completed before parent is completed", function() {
+            const childPayload = {
+                type: "ChildUseCase"
+            };
+            class ChildUseCase extends UseCase {
                 execute() {
-                    this.throwError(new Error("error"));
+                    this.dispatch(childPayload);
                 }
             }
-            const testUseCase = new TestUseCase();
-            // then
-            testUseCase.onDispatch(({type, error}) => {
-                assert(error instanceof Error);
-                done();
+            class ParentUseCase extends UseCase {
+                execute() {
+                    return this.context.useCase(new ChildUseCase()).execute();
+                }
+            }
+            it("should delegate dispatch to parent -> dispatcher", function() {
+                const dispatcher = new Dispatcher();
+                const context = new Context({
+                    dispatcher,
+                    store: new Store()
+                });
+                const dispatchedPayloads = [];
+                dispatcher.onDispatch(payload => {
+                    dispatchedPayloads.push(payload);
+                });
+                return context.useCase(new ParentUseCase()).execute().then(() => {
+                    // childPayload should be delegated to dispatcher(root)
+                    assert(dispatchedPayloads.indexOf(childPayload) !== -1);
+                });
             });
-            // when
-            testUseCase.execute();
+        });
+        /*
+            P: Parent UseCase
+            C: Child UseCase
+
+                            P fin.   C fin.
+            |---------------|          |
+            P    |                     |
+                 C---------------------|
+                                  |
+                              C call dispatch()
+
+         */
+        context("when child is completed after parent did completed", function() {
+            let consoleWarnStub = null;
+            beforeEach(() => {
+                consoleWarnStub = sinon.stub(console, "warn");
+            });
+            afterEach(() => {
+                consoleWarnStub.restore();
+            });
+            it("should delegate dispatch to parent -> dispatcher", function(done) {
+                const childPayload = {
+                    type: "ChildUseCase"
+                };
+                const dispatchedPayloads = [];
+                const finishCallBack = () => {
+                    // childPayload should not be delegated to dispatcher(root)
+                    assert(dispatchedPayloads.indexOf(childPayload) === -1);
+                    // insteadof of it, should be display warning messages
+                    assert(consoleWarnStub.called);
+                    const warningMessage = consoleWarnStub.getCalls()[0].args[0];
+                    assert(/UseCase.*?is already released/.test(warningMessage), warningMessage);
+                    done();
+                };
+                class ChildUseCase extends UseCase {
+                    execute() {
+                        this.dispatch(childPayload);
+                        finishCallBack();
+                    }
+                }
+                class ParentUseCase extends UseCase {
+                    execute() {
+                        // ChildUseCase is independent from Parent
+                        // But, ChildUseCase is executed from Parent
+                        // This is programming error
+                        setTimeout(() => {
+                            this.context.useCase(new ChildUseCase()).execute();
+                        }, 16);
+                        return Promise.resolve();
+                    }
+                }
+
+                const dispatcher = new Dispatcher();
+                const context = new Context({
+                    dispatcher,
+                    store: new Store()
+                });
+                dispatcher.onDispatch(payload => {
+                    dispatchedPayloads.push(payload);
+                });
+                context.useCase(new ParentUseCase()).execute();
+            });
         });
     });
 });


### PR DESCRIPTION
Following case is violation of UseCase lifecycle.
Almin don't support this pattern.

```
P: Parent UseCase
C: Child UseCase

                P fin.   C fin.
|---------------|          |
P    |                     |
     C---------------------|
```

Example:

```js
class ChildUseCase extends UseCase {}
class ParentUseCase extends UseCase {
    execute() {
        setTimeout(() => {
            // isolate execution
            this.context.useCase(new ChildUseCase()).execute().then(() => {
                // ChildUseCase's dispatch is not work!
            });
        }, 100);
        return Promise.resolve();
    }
}
```

However, Almin should display warning message.
We want to add warning message to this case.

Edit:

See https://almin.js.org/docs/warnings/usecase-is-already-released.html for more details.

## Implementation

- Add `UseCaseInstanceMap` for managing instance of each UseCase.
   - Similar with https://github.com/facebook/react/blob/15.5-dev/src/renderers/shared/shared/ReactInstanceMap.js
- Assert: exsit parent UseCase instance on `_willExecute` and `_complete`.

```
P: Parent UseCase
C: Child UseCase
Add: Add instance to UseCaseInstanceMap
Delete: Remove instance from UseCaseInstanceMap

Add P         Delete P   Delete P
|---------------|          |
P    |                     |
     C---------------------|
  Add C
  
  
```