### PR TITLE
fix(TypeScript): use @types/object-assign instead of object-assign.d.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "build:docs": "gitbook build",
     "build": "npm-run-all -s clean build:src build:lib",
     "build:src": "npm-run-all -p build:src:*",
-    "build:src:cp_obj": "cpx 'src/**/*.{js, jsx}' __obj/src --preserve",
     "build:src:tsc": "tsc --project .",
     "build:lib": "npm-run-all -p build:lib:*",
     "build:lib:cp_lib": "cpx '__obj/src/**/*.d.ts' lib/ --preserve",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
   "devDependencies": {
     "@alrra/travis-scripts": "^3.0.1",
     "@types/node": "^7.0.5",
+    "@types/object-assign": "^4.0.30",
     "add-text-to-markdown": "^1.0.2",
     "babel-cli": "^6.7.5",
     "babel-eslint": "^7.1.1",

--- a/src/UILayer/QueuedStoreGroup.ts
+++ b/src/UILayer/QueuedStoreGroup.ts
@@ -1,8 +1,8 @@
 // LICENSE : MIT
 "use strict";
-// polyfill Object.assign
+
 import * as assert from "assert";
-import ObjectAssign from "./object-assign";
+import ObjectAssign from "object-assign";
 import LRU from "lru-map-like";
 const CHANGE_STORE_GROUP = "CHANGE_STORE_GROUP";
 

--- a/src/UILayer/StoreGroup.ts
+++ b/src/UILayer/StoreGroup.ts
@@ -1,8 +1,7 @@
 // LICENSE : MIT
 "use strict";
 
-// polyfill Object.assign
-import ObjectAssign from "./object-assign";
+import ObjectAssign from "object-assign";
 import * as assert from "assert";
 import LRU from "lru-map-like";
 

--- a/src/UILayer/object-assign.d.ts
+++ b/src/UILayer/object-assign.d.ts
@@ -1,4 +1,0 @@
-// FIXME: this is temporary loading hack.
-// This should be fixed in lru-map-like,
-declare const Fn: typeof Object.assign;
-export default Fn;

--- a/src/UILayer/object-assign.js
+++ b/src/UILayer/object-assign.js
@@ -1,4 +1,0 @@
-// FIXME: this is temporary loading hack.
-// This should be fixed in lru-map-like,
-import ObjectAssign from "object-assign";
-export default ObjectAssign;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "allowJs": false, // use as a static type checker
-        "allowSyntheticDefaultImports": false,
+        "allowSyntheticDefaultImports": true,
         "allowUnreachableCode": false,
         "allowUnusedLabels": false,
         // ES Modules are always parsed as in strict mode.
@@ -34,7 +34,8 @@
         "suppressImplicitAnyIndexErrors": false,
         "target": "esnext",
         "types": [
-            "node"
+            "node",
+            "object-assign"
         ]
     },
 


### PR DESCRIPTION
- enable `allowSyntheticDefaultImports`  for loading `@types/object-assign`
- remove "build:src:cp_obj" task. it is no more needed.

fix #89