### PR TITLE
[Discussion] feat(UseCase): Add Stateless|Functional UseCase

### DIFF
--- a/src/DispatcherPayloadMeta.ts
+++ b/src/DispatcherPayloadMeta.ts
@@ -3,9 +3,10 @@
 
 import { Dispatcher } from "./Dispatcher";
 import { UseCase } from "./UseCase";
+import { UseCaseLike } from "./UseCaseLike";
 
 export interface DispatcherPayloadMetaArgs {
-    useCase?: UseCase;
+    useCase?: UseCaseLike;
     dispatcher?: Dispatcher | Dispatcher;
     parentUseCase?: UseCase | null;
     /**
@@ -18,7 +19,7 @@ export interface DispatcherPayloadMeta {
     /**
      * A reference to the useCase/dispatcher to which the payload was originally dispatched.
      */
-    readonly useCase: UseCase | null;
+    readonly useCase: UseCaseLike | null;
 
     /**
      * A dispatcher of the payload
@@ -66,7 +67,7 @@ export interface DispatcherPayloadMeta {
  * });
  */
 export class DispatcherPayloadMetaImpl implements DispatcherPayloadMeta {
-    readonly useCase: UseCase | null;
+    readonly useCase: UseCaseLike | null;
     readonly dispatcher: UseCase | Dispatcher | null;
     readonly parentUseCase: UseCase | Dispatcher | null;
     readonly timeStamp: number;

--- a/src/StatelessUseCase.ts
+++ b/src/StatelessUseCase.ts
@@ -1,0 +1,75 @@
+// LICENSE : MIT
+"use strict";
+import { StatelessUseCaseContext } from "./StatelessUseCaseContext";
+import { UseCaseLike } from "./UseCaseLike";
+import { Dispatcher } from "./Dispatcher";
+import { DispatcherPayloadMetaImpl } from "./DispatcherPayloadMeta";
+import { ErrorPayload } from "./payload/ErrorPayload";
+import { generateNewId } from "./UseCaseIdGenerator";
+
+export const defaultUseCaseName = "<Stateless-UseCase>";
+
+/**
+ * Stateless|Functional version of UseCase class
+ * It has some limitation by contrast to UseCase class
+ *
+ * - Can not use lifecycle hook
+ * - Always willExecute `args` is null
+ */
+export class StatelessUseCase extends Dispatcher implements UseCaseLike {
+
+    /**
+     * unique id in each UseCase instances.
+     */
+    id: string;
+
+    /**
+     * Executor function
+     */
+    executor: Function;
+
+    /**
+     * Dispatcher
+     */
+    dispatcher: Dispatcher;
+
+    /**
+     * The default is UseCase name
+     */
+    name: string;
+
+    constructor(executor: Function & {name?: string, displayName?: string}, dispatcher: Dispatcher) {
+        super();
+        this.dispatcher = dispatcher;
+        this.executor = executor;
+        this.id = generateNewId();
+        this.name = executor.displayName || executor.name || defaultUseCaseName;
+    }
+
+    /**
+     * execute stateless usecase
+     */
+    execute(): any {
+        const context: StatelessUseCaseContext = {
+            dispatcher: this.dispatcher
+        };
+        return this.executor(context);
+    }
+
+    /**
+     * throw error event
+     * you can use it instead of `throw new Error()`
+     * this error event is caught by dispatcher.
+     */
+    throwError(error?: Error | any): void {
+        const meta = new DispatcherPayloadMetaImpl({
+            useCase: this,
+            dispatcher: this,
+            isTrusted: true
+        });
+        const payload = new ErrorPayload({
+            error
+        });
+        this.dispatch(payload, meta);
+    }
+}

--- a/src/StatelessUseCaseContext.ts
+++ b/src/StatelessUseCaseContext.ts
@@ -1,0 +1,9 @@
+// LICENSE : MIT
+"use strict";
+import { Dispatcher } from "./Dispatcher";
+/**
+ * StatelessUseCaseContext is a Context object in Stateless UseCase
+ */
+export interface StatelessUseCaseContext {
+    dispatcher: Dispatcher;
+}

--- a/src/UseCase.ts
+++ b/src/UseCase.ts
@@ -5,17 +5,8 @@ import { DispatchedPayload } from "./Dispatcher";
 import { UseCaseContext } from "./UseCaseContext";
 import { DispatcherPayloadMeta, DispatcherPayloadMetaImpl } from "./DispatcherPayloadMeta";
 import { ErrorPayload, isErrorPayload } from "./payload/ErrorPayload";
-/**
- * UseCase incremental count is for Unique ID.
- */
-let _UseCaseCount: number = 0;
-/**
- * create new id
- */
-const createNewID = (): string => {
-    _UseCaseCount++;
-    return String(_UseCaseCount);
-};
+import { UseCaseLike } from "./UseCaseLike";
+import { generateNewId } from "./UseCaseIdGenerator";
 
 export const defaultUseCaseName = "<Anonymous-UseCase>";
 
@@ -30,7 +21,7 @@ export const defaultUseCaseName = "<Anonymous-UseCase>";
     }
  }
  */
-export abstract class UseCase extends Dispatcher {
+export abstract class UseCase extends Dispatcher implements UseCaseLike {
 
     /**
      * Debuggable name if it needed
@@ -63,7 +54,7 @@ export abstract class UseCase extends Dispatcher {
     constructor() {
         super();
 
-        this.id = createNewID();
+        this.id = generateNewId();
         const own = this.constructor as typeof UseCase;
         this.name = own.displayName || own.name || defaultUseCaseName;
     }

--- a/src/UseCaseContext.ts
+++ b/src/UseCaseContext.ts
@@ -3,6 +3,7 @@
 
 import { UseCase } from "./UseCase";
 import { UseCaseExecutor } from "./UseCaseExecutor";
+import { Dispatcher } from "./Dispatcher";
 
 const assert = require("assert");
 /**
@@ -13,13 +14,13 @@ const assert = require("assert");
  */
 export class UseCaseContext {
 
-    dispatcher: UseCase;
+    dispatcher: UseCase | Dispatcher;
 
     /**
      * @param   dispatcher
      *  The parent UseCase.
      */
-    constructor(dispatcher: UseCase) {
+    constructor(dispatcher: UseCase | Dispatcher) {
         this.dispatcher = dispatcher;
     }
 
@@ -33,7 +34,7 @@ export class UseCaseContext {
         }
         return new UseCaseExecutor({
             useCase,
-            parent: this.dispatcher,
+            parent: UseCase.isUseCase(this.dispatcher) ? this.dispatcher : null,
             dispatcher: this.dispatcher
         });
     }

--- a/src/UseCaseExecutor.ts
+++ b/src/UseCaseExecutor.ts
@@ -9,9 +9,10 @@ import { DispatcherPayloadMeta, DispatcherPayloadMetaImpl } from "./DispatcherPa
 import { CompletedPayload, isCompletedPayload } from "./payload/CompletedPayload";
 import { DidExecutedPayload, isDidExecutedPayload } from "./payload/DidExecutedPayload";
 import { WillExecutedPayload, isWillExecutedPayload } from "./payload/WillExecutedPayload";
+import { UseCaseLike } from "./UseCaseLike";
 
 export interface UseCaseExecutorArgs {
-    useCase: UseCase;
+    useCase: UseCaseLike;
     parent: UseCase | null;
     dispatcher: Dispatcher;
 }
@@ -24,7 +25,7 @@ export class UseCaseExecutor {
     /**
      *  executable useCase
      */
-    useCase: UseCase;
+    useCase: UseCaseLike;
 
     /**
      * parent useCase
@@ -50,9 +51,9 @@ export class UseCaseExecutor {
         parent,
         dispatcher
     }: UseCaseExecutorArgs) {
-        // execute and finish =>
-        const useCaseName = useCase.name;
         if (process.env.NODE_ENV !== "production") {
+            // execute and finish =>
+            const useCaseName = useCase.name;
             assert.ok(typeof useCaseName === "string", `UseCase instance should have constructor.name ${useCase}`);
             assert.ok(typeof useCase.execute === "function", `UseCase instance should have #execute function: ${useCaseName}`);
         }
@@ -162,6 +163,7 @@ export class UseCaseExecutor {
     /**
      * execute UseCase instance.
      * UseCase is a executable object. it means that has `execute` method.
+     * Notes: UseCaseExecutor doesn't return resolved value by design
      * @param args
      */
     execute<R>(...args: Array<any>): Promise<void> {

--- a/src/UseCaseIdGenerator.ts
+++ b/src/UseCaseIdGenerator.ts
@@ -1,0 +1,11 @@
+/**
+ * UseCase incremental count is for Unique ID.
+ */
+let _UseCaseCount: number = 0;
+/**
+ * create new id
+ */
+export const generateNewId = (): string => {
+    _UseCaseCount++;
+    return String(_UseCaseCount);
+};

--- a/src/UseCaseLike.ts
+++ b/src/UseCaseLike.ts
@@ -1,0 +1,9 @@
+// LICENSE : MIT
+"use strict";
+import { Dispatcher } from "./Dispatcher";
+export interface UseCaseLike extends Dispatcher {
+    name: string;
+    execute<R>(...args: Array<any>): R;
+    throwError(error: Error): void;
+}
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ export { StoreGroup } from "./UILayer/StoreGroup";
 export { QueuedStoreGroup } from "./UILayer/QueuedStoreGroup";
 export { UseCase } from "./UseCase";
 export { Context } from "./Context";
+export { StatelessUseCaseContext } from "./StatelessUseCaseContext";
 export { CompletedPayload } from "./payload/CompletedPayload";
 export { DidExecutedPayload } from "./payload/DidExecutedPayload";
 export { Payload } from "./payload/Payload";

--- a/test/typescript/almin-test.ts
+++ b/test/typescript/almin-test.ts
@@ -9,7 +9,8 @@ import {
     DidExecutedPayload,
     CompletedPayload,
     ErrorPayload,
-    DispatcherPayloadMeta
+    DispatcherPayloadMeta,
+    StatelessUseCaseContext
 } from "../../src/index";
 // Dispatcher
 const dispatcher = new Dispatcher();
@@ -82,7 +83,6 @@ context.onErrorDispatch((payload: ErrorPayload, meta: DispatcherPayloadMeta) => 
 context.onDispatch((payload: Payload, meta: DispatcherPayloadMeta) => {
     console.log(payload.type, meta);
 });
-
 // UseCase
 class ChildUseCase extends UseCase {
     execute(value: string) {
@@ -99,7 +99,21 @@ class ParentUseCase extends UseCase {
     }
 }
 const parentUseCase = new ParentUseCase();
-// UseCase - execute
+// Stateless UseCase
+const statelessUseCase = (value: string) => {
+    return (context: StatelessUseCaseContext) => {
+        context.dispatcher.dispatch({
+            type: value
+        });
+    }
+};
+// run - stateless execute
+context.run(statelessUseCase("value")).then(() => {
+    const state = context.getState<StoreState>();
+    console.log(state.A.a);
+    console.log(state.B.b);
+});
+// execute: usecase
 context.useCase(parentUseCase).execute("value").then(() => {
     const state = context.getState<StoreState>();
     console.log(state.A.a);


### PR DESCRIPTION
This PR is a POC #63 

We have filed issue that is "Function as a UseCase #63"

This PR allow to use functional usecase like following:

```js
const useCase = (value) => {
     return ({ dispatcher }) => {
         // do something
     }
};
context.run(useCase("value")).then(() => { });
```


functional usecase get some limitation.

- Can not use lifecycle hook
  - omit `onError` etc... method
- Always willExecute `args` is null
  - we have not the way that getting `args` of execution.