### PR TITLE
fix(StoreGroup): rename `get store()` to `get stores()`

### DIFF
--- a/src/UILayer/StoreGroup.ts
+++ b/src/UILayer/StoreGroup.ts
@@ -84,7 +84,7 @@ export class StoreGroup extends Dispatcher implements StoreLike {
     /**
      * A collection of stores in the StoreGroup.
      */
-    get store(): Array<Store> {
+    get stores(): Array<Store> {
         return this._stores;
     }
 


### PR DESCRIPTION
it is a typo :(

fix #140 