### PR TITLE
Breaking Change: remove the arguments of Store#getState

### DIFF
--- a/src/Store.ts
+++ b/src/Store.ts
@@ -98,24 +98,37 @@ export abstract class Store extends Dispatcher implements StoreLike {
     /**
      * ## Write phase in read-side
      *
-     * You can update own state.
+     * You can implement that update own state.
+     *
+     * Write phase in read-side, receive tha payload from write-side.
+     * In the almin, UseCase(write-side) dispatch a payload and, Store receive the payload.
+     * You can update the state of the store in the timing.
+     * In other word, you can create/cache the state data for `Store#getState()`
      */
     receivePayload?(payload: Payload): void;
 
     /**
-     * If the prev/next state is difference, should return true.
+     * ## Read phase in read-side
+     *
+     * You should be overwrite by Store subclass and return the state of the store.
+     *
+     * Read phase in read-side, just return the state of the store.
+     * Store#getState is called at View needed new state.
+     *
+     * When the state has updated, the view will be updated.
+     * Usually, use Store#shouldStateUpdate for detecting update of the state.
      */
-    shouldStateUpdate<T>(prevState: T, nextState: T): boolean {
-        return !shallowEqual(prevState, nextState);
-    }
+    abstract getState<T>(): T;
 
     /**
-     * ## Read-phase in read-side
+     * If the prev/next state is difference, should return true.
      *
-     * You should be overwrite by Store subclass.
-     * Next, return state object of your store.
+     * Use Shallow Object Equality Test by default.
+     * <https://github.com/sebmarkbage/ecmascript-shallow-equal>
      */
-    abstract getState<T>(prevState?: T): T;
+    shouldStateUpdate(prevState: any, nextState: any): boolean {
+        return !shallowEqual(prevState, nextState);
+    }
 
     /**
      * Subscribe change event of the store.

--- a/src/StoreLike.ts
+++ b/src/StoreLike.ts
@@ -7,7 +7,7 @@ export interface StoreLike {
     receivePayload?(payload: Payload): void;
     // read phase in read-side
     // you should return own state
-    getState<T>(prevState?: T): T;
+    getState<T>(): T;
     onChange(onChangeHandler: (hangingStores: Array<StoreLike>) => void): () => void;
     release?(): void;
 }

--- a/src/UILayer/QueuedStoreGroup.ts
+++ b/src/UILayer/QueuedStoreGroup.ts
@@ -3,7 +3,6 @@
 
 import * as assert from "assert";
 import ObjectAssign from "object-assign";
-import LRU from "lru-map-like";
 const CHANGE_STORE_GROUP = "CHANGE_STORE_GROUP";
 
 import { Dispatcher } from "./../Dispatcher";
@@ -70,7 +69,6 @@ export class QueuedStoreGroup extends Dispatcher implements StoreLike {
     private _releaseHandlers: Array<Function>;
     private _currentChangingStores: Array<Store>;
     private stores: Array<Store>;
-    private _stateCache: LRU<Store, any>;
     private _isAnyOneStoreChanged: boolean;
 
     /**
@@ -104,12 +102,6 @@ export class QueuedStoreGroup extends Dispatcher implements StoreLike {
         this.stores = stores;
         // listen onChange of each store.
         this.stores.forEach(store => this._registerStore(store));
-        /**
-         * LRU Cache for Store and State
-         * @type {LRU}
-         * @private
-         */
-        this._stateCache = new LRU<Store, any>(100);
         // `this` can catch the events of dispatchers
         // Because context delegate dispatched events to **this**
         const tryToEmitChange = (payload: DispatchedPayload, meta: DispatcherPayloadMetaImpl) => {
@@ -176,8 +168,7 @@ export class QueuedStoreGroup extends Dispatcher implements StoreLike {
              Why record nextState to `_storeValueMap`?
              It is for Use Store's getState(prevState) implementation.
              */
-            const prevState = this._stateCache.get(store);
-            const nextState = store.getState(prevState);
+            const nextState = store.getState();
             if (process.env.NODE_ENV !== "production") {
                 assert.ok(typeof nextState == "object", `${store}: ${store.name}.getState() should return Object.
 e.g.)
@@ -196,7 +187,6 @@ StoreGroup#getState()["StateName"]; // state
 
 `);
             }
-            this._stateCache.set(store, nextState);
             return nextState;
         });
         return ObjectAssign({}, ...stateMap);
@@ -272,7 +262,6 @@ StoreGroup#getState()["StateName"]; // state
     release(): void {
         this._releaseHandlers.forEach(releaseHandler => releaseHandler());
         this._releaseHandlers.length = 0;
-        this._stateCache.clear();
     }
 
     /**

--- a/src/UILayer/StoreGroup.ts
+++ b/src/UILayer/StoreGroup.ts
@@ -126,7 +126,7 @@ export class StoreGroup extends Dispatcher implements StoreLike {
             if (prevState && this._previousChangingStores.indexOf(store) === -1) {
                 return prevState;
             }
-            const nextState = store.getState(prevState);
+            const nextState = store.getState();
             if (process.env.NODE_ENV !== "production") {
                 assert.ok(typeof nextState == "object", `${store}: ${store.name}.getState() should return Object.
 e.g.)

--- a/test/CQRSStoreGroup-test.js
+++ b/test/CQRSStoreGroup-test.js
@@ -591,14 +591,14 @@ describe("CQRSStoreGroup", function() {
                 class AState {
                 }
                 class AStore extends Store {
-                    getState(_prev) {
+                    getState() {
                         return new AState();
                     }
                 }
                 class BState {
                 }
                 class BStore extends Store {
-                    getState(_prev) {
+                    getState() {
                         return new BState();
                     }
                 }


### PR DESCRIPTION
Continute to `feat(Store): add Store#receivePayload(payload: Payload)` #160

## Breaking Changes

- Remove the `prevState` argument of `Store#getState(prevState)`

### Background

We have introduced `Store#receivePayload(payload)` in #160 
This method aim to separate  **write in read** and **read in read**.
It is mixed context in a single method.

`Store#getState(prevState)` make us confuse.
The user could implement write and read using `getState(prevState)`.

```js
const initialState = 0;
class MyStore extends Store {
     getState(prevState = initialState){
         return prevState + 1;
     }
}
```

We can implement this instadof the above mixed context implementation.

```ts
class Reactor extends Store {
    receivePayload() {
        const newState = this.reduce(this.state);
        if (this.shouldStateUpdate(this.state, newState)) {
            this.state = newState;
        }
    }

    getState() {
        return this.state;
    }
}
// The user implement this
const initialState = 0;
class MyStore extends Reactor {
    reduce(prevState = initialState){
        return prevState + 1;
    }
}
```

I've described it in https://github.com/almin/almin/pull/160#issuecomment-294336153

---

## Notes 📝 

Will be release in  0.12 #161 