### PR TITLE
chore(Store): Make clear the relation Store and State

### DIFF
--- a/src/Context.ts
+++ b/src/Context.ts
@@ -5,7 +5,7 @@ import { Dispatcher } from "./Dispatcher";
 import { DispatchedPayload } from "./Dispatcher";
 import { DispatcherPayloadMeta } from "./DispatcherPayloadMeta";
 import { UseCase } from "./UseCase";
-import { Store } from "./Store";
+import { AnyStore } from "./Store";
 import { StoreLike } from "./StoreLike";
 import { UseCaseExecutor } from "./UseCaseExecutor";
 import { StoreGroupValidator } from "./UILayer/StoreGroupValidator";
@@ -107,8 +107,8 @@ export class Context {
      * });
      * ```
      */
-    onChange(onChangeHandler: (changingStores: Array<Store>) => void): () => void {
-        return this._storeGroup.onChange(onChangeHandler);
+    onChange(handler: (changingStores: Array<AnyStore>) => void): () => void {
+        return this._storeGroup.onChange(handler);
     }
 
     /**

--- a/src/Context.ts
+++ b/src/Context.ts
@@ -25,7 +25,7 @@ export class Context {
      * @private
      */
     private _dispatcher: Dispatcher;
-    private _storeGroup: StoreLike & Dispatcher;
+    private _storeGroup: StoreLike;
     private _releaseHandlers: Array<() => void>;
 
     /**
@@ -55,7 +55,7 @@ export class Context {
      * });
      * ```
      */
-    constructor({dispatcher, store}: {dispatcher: Dispatcher; store: Store | StoreLike & Dispatcher;}) {
+    constructor({dispatcher, store}: {dispatcher: Dispatcher; store: StoreLike;}) {
         StoreGroupValidator.validateInstance(store);
         // central dispatcher
         this._dispatcher = dispatcher;
@@ -264,7 +264,7 @@ The argument is UseCase constructor itself: ${useCase}`
      */
     release() {
         const storeGroup = this._storeGroup;
-        if (!!storeGroup && typeof storeGroup.release === "function") {
+        if (storeGroup) {
             storeGroup.release();
         }
         this._releaseHandlers.forEach(releaseHandler => releaseHandler());

--- a/src/Store.ts
+++ b/src/Store.ts
@@ -6,6 +6,8 @@ import { shallowEqual } from "shallow-equal-object";
 import { Payload } from "./payload/Payload";
 
 const STATE_CHANGE_EVENT = "STATE_CHANGE_EVENT";
+// TODO: will remove by default generics
+export type AnyStore = Store<any>
 
 /**
  * @type {string}
@@ -60,7 +62,7 @@ export const defaultStoreName = "<Anonymous-Store>";
  * }
  * ```
  */
-export abstract class Store extends Dispatcher implements StoreLike {
+export abstract class Store<State> extends Dispatcher implements StoreLike {
     /**
      * Set debuggable name if needed.
      */
@@ -69,7 +71,7 @@ export abstract class Store extends Dispatcher implements StoreLike {
     /**
      * Return true if the `v` is store like.
      */
-    static isStore(v: any): v is Store {
+    static isStore(v: any): v is Store<any> {
         if (v instanceof Store) {
             return true;
         } else if (typeof v === "object" && typeof v.getState === "function" && typeof v.onChange === "function") {
@@ -77,6 +79,11 @@ export abstract class Store extends Dispatcher implements StoreLike {
         }
         return false;
     }
+
+    /**
+     * The state of the Store.
+     */
+    state?: State;
 
     /**
      * The name of the Store.
@@ -126,7 +133,7 @@ export abstract class Store extends Dispatcher implements StoreLike {
      * Use Shallow Object Equality Test by default.
      * <https://github.com/sebmarkbage/ecmascript-shallow-equal>
      */
-    shouldStateUpdate(prevState: any, nextState: any): boolean {
+    shouldStateUpdate(prevState: any | State, nextState: any | State): boolean {
         return !shallowEqual(prevState, nextState);
     }
 
@@ -166,6 +173,6 @@ export abstract class Store extends Dispatcher implements StoreLike {
 }
 
 // Implement assertion
-Store.prototype.getState = function (this: Store) {
+Store.prototype.getState = function (this: Store<any>) {
     throw new Error(`${this.name} should be implemented Store#getState(): Object`);
 };

--- a/src/Store.ts
+++ b/src/Store.ts
@@ -156,6 +156,13 @@ export abstract class Store extends Dispatcher implements StoreLike {
     emitChange(): void {
         this.emit(STATE_CHANGE_EVENT, [this]);
     }
+
+    /**
+     * Release all event handlers
+     */
+    release(): void {
+        this.removeAllListeners(STATE_CHANGE_EVENT);
+    }
 }
 
 // Implement assertion

--- a/src/StoreLike.ts
+++ b/src/StoreLike.ts
@@ -1,14 +1,13 @@
-// LICENSE : MIT
-
-import { Payload } from "./payload/Payload";
-export interface StoreLike {
-    // write phase in read-side
-    // you can update own state
-    receivePayload?(payload: Payload): void;
-    // read phase in read-side
-    // you should return own state
+import { Dispatcher } from "./Dispatcher";
+/**
+ * StoreLike is a interfere for Store and StoreGroup .
+ */
+export interface StoreLike extends Dispatcher {
+    // Return the state
     getState<T>(): T;
-    // TODO: Add shouldStateUpdate
-    onChange(onChangeHandler: (hangingStores: Array<StoreLike>) => void): () => void;
-    release?(): void;
+    // call the `handler` when the store is changed.
+    // pass changing stores to the `handler`
+    onChange(handler: (stores: Array<StoreLike>) => void): () => void;
+    // release all handler
+    release(): void;
 }

--- a/src/UILayer/QueuedStoreGroup.ts
+++ b/src/UILayer/QueuedStoreGroup.ts
@@ -8,7 +8,7 @@ const CHANGE_STORE_GROUP = "CHANGE_STORE_GROUP";
 import { Dispatcher } from "./../Dispatcher";
 import { DispatchedPayload } from "./../Dispatcher";
 import { DispatcherPayloadMetaImpl } from "./../DispatcherPayloadMeta";
-import { Store } from "./../Store";
+import { AnyStore } from "./../Store";
 import { StoreLike } from "./../StoreLike";
 import { StoreGroupValidator } from "./StoreGroupValidator";
 import { isDidExecutedPayload } from "../payload/DidExecutedPayload";
@@ -67,8 +67,8 @@ export interface QueuedStoreGroupOption {
 export class QueuedStoreGroup extends Dispatcher implements StoreLike {
 
     private _releaseHandlers: Array<Function>;
-    private _currentChangingStores: Array<Store>;
-    private stores: Array<Store>;
+    private _currentChangingStores: Array<AnyStore>;
+    private stores: Array<AnyStore>;
     private _isAnyOneStoreChanged: boolean;
 
     /**
@@ -77,7 +77,7 @@ export class QueuedStoreGroup extends Dispatcher implements StoreLike {
      * @param {Object} [options] QueuedStoreGroup option
      * @public
      */
-    constructor(stores: Array<Store>, options: QueuedStoreGroupOption = {}) {
+    constructor(stores: Array<AnyStore>, options: QueuedStoreGroupOption = {}) {
         super();
         StoreGroupValidator.validateStores(stores);
         const asap = options.asap !== undefined ? options.asap : defaultOptions.asap;
@@ -153,7 +153,7 @@ export class QueuedStoreGroup extends Dispatcher implements StoreLike {
      * @returns {Store[]}
      * @private
      */
-    get currentChangingStores(): Array<Store> {
+    get currentChangingStores(): Array<AnyStore> {
         return this._currentChangingStores;
     }
 
@@ -198,7 +198,7 @@ StoreGroup#getState()["StateName"]; // state
      * @param {Store} store
      * @private
      */
-    private _registerStore(store: Store) {
+    private _registerStore(store: AnyStore) {
         // if anyone store is changed, will call `emitChange()`.
         const releaseOnChangeHandler = store.onChange(() => {
             // ====
@@ -247,7 +247,7 @@ StoreGroup#getState()["StateName"]; // state
      * @returns {Function} call the function and release handler
      * @public
      */
-    onChange(handler: (stores: Array<Store>) => void ): () => void {
+    onChange(handler: (stores: Array<AnyStore>) => void): () => void {
         this.on(CHANGE_STORE_GROUP, handler);
         const releaseHandler = this.removeListener.bind(this, CHANGE_STORE_GROUP, handler);
         this._releaseHandlers.push(releaseHandler);

--- a/src/UILayer/StoreGroup.ts
+++ b/src/UILayer/StoreGroup.ts
@@ -6,7 +6,7 @@ import * as assert from "assert";
 import LRU from "lru-map-like";
 
 import { Dispatcher } from "../Dispatcher";
-import { Store } from "../Store";
+import { AnyStore } from "../Store";
 import { StoreGroupValidator } from "./StoreGroupValidator";
 import { StoreLike } from "../StoreLike";
 import { raq } from "./raq";
@@ -31,11 +31,11 @@ export class StoreGroup extends Dispatcher implements StoreLike {
      * @private definitions
      */
     private _releaseHandlers: Array<Function>;
-    private _currentChangingStores: Array<Store>;
-    private _previousChangingStores: Array<Store>;
-    private _stateCache: LRU<Store, any>;
+    private _currentChangingStores: Array<AnyStore>;
+    private _previousChangingStores: Array<AnyStore>;
+    private _stateCache: LRU<AnyStore, any>;
     private _isAnyOneStoreChanged: boolean;
-    private _stores: Array<Store>;
+    private _stores: Array<AnyStore>;
 
     /**
      * Initialize `StoreGroup` with `Store` instances
@@ -49,7 +49,7 @@ export class StoreGroup extends Dispatcher implements StoreLike {
      * const storeGroup = new StoreGroup([aStore, bStore]);
      * ```
      */
-    constructor(stores: Array<Store>) {
+    constructor(stores: Array<AnyStore>) {
         super();
         StoreGroupValidator.validateStores(stores);
         /**
@@ -78,13 +78,13 @@ export class StoreGroup extends Dispatcher implements StoreLike {
          * @type {LRU}
          * @private
          */
-        this._stateCache = new LRU<Store, any>(100);
+        this._stateCache = new LRU<AnyStore, any>(100);
     }
 
     /**
      * A collection of stores in the StoreGroup.
      */
-    get stores(): Array<Store> {
+    get stores(): Array<AnyStore> {
         return this._stores;
     }
 
@@ -157,7 +157,7 @@ StoreGroup#getState()["StateName"]// state
      * @param {Store} store
      * @private
      */
-    private _registerStore(store: Store): void {
+    private _registerStore(store: AnyStore): void {
         // if anyone store is changed, will call `emitChange()`.
         const releaseOnChangeHandler = store.onChange(() => {
             // true->false, prune previous cache
@@ -223,7 +223,7 @@ StoreGroup#getState()["StateName"]// state
      * subscribe changes of the store group.
      * It is same with `Store#onChage()`
      */
-    onChange(handler: (stores: Array<Store>) => void): () => void {
+    onChange(handler: (stores: Array<AnyStore>) => void): () => void {
         this.on(CHANGE_STORE_GROUP, handler);
         const releaseHandler = this.removeListener.bind(this, CHANGE_STORE_GROUP, handler);
         this._releaseHandlers.push(releaseHandler);

--- a/src/UILayer/StoreGroupValidator.ts
+++ b/src/UILayer/StoreGroupValidator.ts
@@ -1,7 +1,7 @@
 // LICENSE : MIT
 "use strict";
 const assert = require("assert");
-import { Store } from "../Store";
+import { AnyStore, Store } from "../Store";
 import { Dispatcher } from "../Dispatcher";
 import { StoreLike } from "../StoreLike";
 /*
@@ -17,7 +17,7 @@ export class StoreGroupValidator {
      * validate stores in StoreGroup
      * @param {Store[]} stores
      */
-    static validateStores(stores: Array<Store>): void | never {
+    static validateStores(stores: Array<AnyStore>): void | never {
         stores.forEach(store => {
             assert.ok(Store.isStore(store), `${store} should be instance of Store`);
             assert.ok(typeof store.getState === "function", `${store} should implement getState() method.

--- a/src/UILayer/StoreGroupValidator.ts
+++ b/src/UILayer/StoreGroupValidator.ts
@@ -2,8 +2,8 @@
 "use strict";
 const assert = require("assert");
 import { Store } from "../Store";
-import { StoreGroup } from "./StoreGroup";
 import { Dispatcher } from "../Dispatcher";
+import { StoreLike } from "../StoreLike";
 /*
  StoreGroup
 
@@ -32,7 +32,7 @@ StoreGroup merge values of store*s*.`);
      * {@link Context} treat StoreGroup like object as StoreGroup.
      * @param {*|StoreGroup|Store} storeGroup
      */
-    static validateInstance(storeGroup: any | StoreGroup | Store): void | never {
+    static validateInstance(storeGroup: any | StoreLike): void | never {
         assert.ok(storeGroup !== undefined, "store should not be undefined");
         assert.ok(Dispatcher.isDispatcher(storeGroup), "storeGroup should inherit CoreEventEmitter");
         assert.ok(typeof storeGroup.onChange === "function", "StoreGroup should have #onChange method");

--- a/test/typescript/almin-loading-test.ts
+++ b/test/typescript/almin-loading-test.ts
@@ -26,7 +26,7 @@ class LoadingState {
         return new LoadingState(isLoading);
     }
 }
-class LoadingStore extends Store {
+class LoadingStore extends Store<LoadingState> {
     state: LoadingState;
 
     constructor() {

--- a/test/typescript/almin-test.ts
+++ b/test/typescript/almin-test.ts
@@ -18,7 +18,7 @@ const dispatcher = new Dispatcher();
 interface AState {
     a: number
 }
-class AStore extends Store {
+class AStore extends Store<AState> {
     state: AState;
 
     constructor() {
@@ -37,7 +37,7 @@ class AStore extends Store {
 interface BState {
     b: number;
 }
-class BStore extends Store {
+class BStore extends Store<BState> {
     state: BState;
 
     constructor() {


### PR DESCRIPTION
`Store` return a `State`

```ts
class Store<State> { 
     state?: State;
     getState(): State;
}
```

fix #163 