### PR TITLE
feat(TypeScript): Make Context#getState explicit

### DIFF
--- a/src/Context.ts
+++ b/src/Context.ts
@@ -16,16 +16,17 @@ import { ErrorPayload, isErrorPayload } from "./payload/ErrorPayload";
 import { WillExecutedPayload, isWillExecutedPayload } from "./payload/WillExecutedPayload";
 import { FunctionalUseCaseContext } from "./FunctionalUseCaseContext";
 import { FunctionalUseCase } from "./FunctionalUseCase";
+import { MapState } from "./UILayer/StoreGroupType";
 
 /**
  * Context class provide observing and communicating with **Store** and **UseCase**.
  */
-export class Context {
+export class Context<T> {
     /**
      * @private
      */
     private _dispatcher: Dispatcher;
-    private _storeGroup: StoreLike;
+    private _storeGroup: StoreLike<T>;
     private _releaseHandlers: Array<() => void>;
 
     /**
@@ -55,7 +56,7 @@ export class Context {
      * });
      * ```
      */
-    constructor({dispatcher, store}: {dispatcher: Dispatcher; store: StoreLike;}) {
+    constructor({dispatcher, store}: {dispatcher: Dispatcher; store: StoreLike<T>;}) {
         StoreGroupValidator.validateInstance(store);
         // central dispatcher
         this._dispatcher = dispatcher;
@@ -88,8 +89,8 @@ export class Context {
      * // { aState, bState }
      * ```
      */
-    getState<T>(): T {
-        return this._storeGroup.getState<T>();
+    getState(): MapState<T>  {
+        return this._storeGroup.getState();
     }
 
     /**

--- a/src/Store.ts
+++ b/src/Store.ts
@@ -62,7 +62,7 @@ export const defaultStoreName = "<Anonymous-Store>";
  * }
  * ```
  */
-export abstract class Store<State> extends Dispatcher implements StoreLike {
+export abstract class Store<State> extends Dispatcher implements StoreLike<State> {
     /**
      * Set debuggable name if needed.
      */
@@ -151,7 +151,7 @@ export abstract class Store<State> extends Dispatcher implements StoreLike {
      * store.emitChange();
      * ```
      */
-    onChange(cb: (changingStores: Array<StoreLike>) => void): () => void {
+    onChange(cb: (changingStores: Array<Store<any>>) => void): () => void {
         this.on(STATE_CHANGE_EVENT, cb);
         return this.removeListener.bind(this, STATE_CHANGE_EVENT, cb);
     }

--- a/src/StoreLike.ts
+++ b/src/StoreLike.ts
@@ -2,12 +2,12 @@ import { Dispatcher } from "./Dispatcher";
 /**
  * StoreLike is a interfere for Store and StoreGroup .
  */
-export interface StoreLike extends Dispatcher {
+export interface StoreLike<T> extends Dispatcher {
     // Return the state
-    getState<T>(): T;
+    getState(): T;
     // call the `handler` when the store is changed.
     // pass changing stores to the `handler`
-    onChange(handler: (stores: Array<StoreLike>) => void): () => void;
+    onChange(handler: (stores: Array<StoreLike<any>>) => void): () => void;
     // release all handler
     release(): void;
 }

--- a/src/UILayer/CQRSStoreGroup.ts
+++ b/src/UILayer/CQRSStoreGroup.ts
@@ -12,53 +12,9 @@ import { CompletedPayload } from "../payload/CompletedPayload";
 import { shallowEqual } from "shallow-equal-object";
 import { ChangedPayload } from "../payload/ChangedPayload";
 import { Dispatcher } from "../Dispatcher";
+import { MapState, MapStore, GroupState } from "./StoreGroupType";
 const CHANGE_STORE_GROUP = "CHANGE_STORE_GROUP";
 
-
-/**
- * This function is type converter for TypeScript.
- * It has actual implementation, but it is only used for typing.
- *
- * - Status: unstable
- * 
- * This is useful for TypeScript, but it is unstable API.
- * You can use it own risk.
- * 
- * ## Example
- *
- * ```ts
- * const mapping = {
- *   a: new AStore(), // AStore<AState>
- *   b: new BStore()  // BStore<BState>
- * };
- * const StoreState = MapStoreToState(mapping);
- * // Get Mapped to State for Store
- * type States = typeof StoreState
- * // {
- * //   a: AState,
- * //   b: BState
- * // };
- * ```
- */
-export function MapStoreToState<T>(_mapping: MapStore<T>): MapState<T> {
-    return {} as MapState<T>
-}
-
-export interface GroupState {
-    // stateName: state
-    [key: string]: any
-}
-// stateName: Store in constructor
-export type MapStore<T> = {
-    // assign T[P] to State
-    [P in keyof T]: Store<T[P]>
-};
-
-export type MapState<T> = {
-    // MapStore define T[P]
-    // Now, T[P] is State
-    [P in keyof T]: T[P]
-};
 // Internal Payload class
 class InitializedPayload extends Payload {
     constructor() {

--- a/src/UILayer/CQRSStoreGroup.ts
+++ b/src/UILayer/CQRSStoreGroup.ts
@@ -17,7 +17,7 @@ const CHANGE_STORE_GROUP = "CHANGE_STORE_GROUP";
 
 /**
  * This function is type converter for TypeScript.
- * It has actual implementation, but it is only use for typing.
+ * It has actual implementation, but it is only used for typing.
  *
  * - Status: unstable
  * 

--- a/src/UILayer/CQRSStoreGroup.ts
+++ b/src/UILayer/CQRSStoreGroup.ts
@@ -28,8 +28,8 @@ const CHANGE_STORE_GROUP = "CHANGE_STORE_GROUP";
  *
  * ```ts
  * const mapping = {
- *   a: new AStore(),
- *   b: new BStore()
+ *   a: new AStore(), // AStore<AState>
+ *   b: new BStore()  // BStore<BState>
  * };
  * const StoreState = MapStoreToState(mapping);
  * // Get Mapped to State for Store

--- a/src/UILayer/CQRSStoreGroup.ts
+++ b/src/UILayer/CQRSStoreGroup.ts
@@ -14,6 +14,36 @@ import { ChangedPayload } from "../payload/ChangedPayload";
 import { Dispatcher } from "../Dispatcher";
 const CHANGE_STORE_GROUP = "CHANGE_STORE_GROUP";
 
+
+/**
+ * This function is type converter for TypeScript.
+ * It has actual implementation, but it is only use for typing.
+ *
+ * - Status: unstable
+ * 
+ * This is useful for TypeScript, but it is unstable API.
+ * You can use it own risk.
+ * 
+ * ## Example
+ *
+ * ```ts
+ * const mapping = {
+ *   a: new AStore(),
+ *   b: new BStore()
+ * };
+ * const StoreState = MapStoreToState(mapping);
+ * // Get Mapped to State for Store
+ * type States = typeof StoreState
+ * // {
+ * //   a: AState,
+ * //   b: BState
+ * // };
+ * ```
+ */
+export function MapStoreToState<T>(_mapping: MapStore<T>): MapState<T> {
+    return {} as MapState<T>
+}
+
 export interface GroupState {
     // stateName: state
     [key: string]: any

--- a/src/UILayer/QueuedStoreGroup.ts
+++ b/src/UILayer/QueuedStoreGroup.ts
@@ -14,6 +14,7 @@ import { StoreGroupValidator } from "./StoreGroupValidator";
 import { isDidExecutedPayload } from "../payload/DidExecutedPayload";
 import { isErrorPayload } from "../payload/ErrorPayload";
 import { isCompletedPayload } from "../payload/CompletedPayload";
+import { MapState } from "./StoreGroupType";
 
 /**
  * QueuedStoreGroup options
@@ -64,7 +65,7 @@ export interface QueuedStoreGroupOption {
  *
  * @public
  */
-export class QueuedStoreGroup extends Dispatcher implements StoreLike {
+export class QueuedStoreGroup<T> extends Dispatcher implements StoreLike<T> {
 
     private _releaseHandlers: Array<Function>;
     private _currentChangingStores: Array<AnyStore>;
@@ -162,7 +163,7 @@ export class QueuedStoreGroup extends Dispatcher implements StoreLike {
      * @returns {Object} merged state object
      * @public
      */
-    getState<T>(): T {
+    getState(): MapState<T>  {
         const stateMap = this.stores.map(store => {
             /*
              Why record nextState to `_storeValueMap`?

--- a/src/UILayer/StoreGroup.ts
+++ b/src/UILayer/StoreGroup.ts
@@ -10,6 +10,7 @@ import { AnyStore } from "../Store";
 import { StoreGroupValidator } from "./StoreGroupValidator";
 import { StoreLike } from "../StoreLike";
 import { raq } from "./raq";
+import { MapState } from "./StoreGroupType";
 
 const CHANGE_STORE_GROUP = "CHANGE_STORE_GROUP";
 
@@ -26,7 +27,7 @@ const CHANGE_STORE_GROUP = "CHANGE_STORE_GROUP";
  *
  * If you want to know all change events, and directly use `store.onChange()`.
  */
-export class StoreGroup extends Dispatcher implements StoreLike {
+export class StoreGroup<T> extends Dispatcher implements StoreLike<T> {
     /**
      * @private definitions
      */
@@ -105,7 +106,7 @@ export class StoreGroup extends Dispatcher implements StoreLike {
      *
      * ```
      */
-    getState<T>(): T {
+    getState(): MapState<T>  {
         const stateMap = this._stores.map(store => {
             /* Why record nextState to `_storeValueMap`.
              It is for Use Store's getState(prevState) implementation.

--- a/src/UILayer/StoreGroupType.ts
+++ b/src/UILayer/StoreGroupType.ts
@@ -1,0 +1,17 @@
+// MIT © 2017 azu
+import { Store } from "../Store";
+// { stateName: state }
+export interface GroupState {
+    [key: string]: any
+}
+// { stateName: Store }
+export type MapStore<T> = {
+    // assign T[P] to State
+    [P in keyof T]: Store<T[P]>
+};
+// { stateName: State }
+export type MapState<T> = {
+    // MapStore define T[P]
+    // Now, T[P] is State
+    [P in keyof T]: T[P]
+};

--- a/src/UILayer/StoreGroupValidator.ts
+++ b/src/UILayer/StoreGroupValidator.ts
@@ -32,7 +32,7 @@ StoreGroup merge values of store*s*.`);
      * {@link Context} treat StoreGroup like object as StoreGroup.
      * @param {*|StoreGroup|Store} storeGroup
      */
-    static validateInstance(storeGroup: any | StoreLike): void | never {
+    static validateInstance(storeGroup: any | StoreLike<any>): void | never {
         assert.ok(storeGroup !== undefined, "store should not be undefined");
         assert.ok(Dispatcher.isDispatcher(storeGroup), "storeGroup should inherit CoreEventEmitter");
         assert.ok(typeof storeGroup.onChange === "function", "StoreGroup should have #onChange method");

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,3 +15,5 @@ export { ChangedPayload } from "./payload/ChangedPayload";
 export { ErrorPayload } from "./payload/ErrorPayload";
 export { WillExecutedPayload } from "./payload/WillExecutedPayload";
 export { DispatcherPayloadMeta } from "./DispatcherPayloadMeta";
+// Experimental TypeScript API
+export { MapStoreToState } from "./UILayer/CQRSStoreGroup";

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,5 +15,3 @@ export { ChangedPayload } from "./payload/ChangedPayload";
 export { ErrorPayload } from "./payload/ErrorPayload";
 export { WillExecutedPayload } from "./payload/WillExecutedPayload";
 export { DispatcherPayloadMeta } from "./DispatcherPayloadMeta";
-// Experimental TypeScript API
-export { MapStoreToState } from "./UILayer/CQRSStoreGroup";

--- a/test/typescript/almin-test.ts
+++ b/test/typescript/almin-test.ts
@@ -10,7 +10,6 @@ import {
     ErrorPayload,
     DispatcherPayloadMeta,
     FunctionalUseCaseContext,
-    MapStoreToState,
     CQRSStoreGroup
 } from "../../src/index";
 // Dispatcher
@@ -54,14 +53,11 @@ class BStore extends Store<BState> {
         };
     }
 }
-const mapping = {
+// Type hacking
+const storeGroup = new CQRSStoreGroup({
     aState: new AStore(),
     bState: new BStore()
-};
-// Type hacking
-const _StoreState = MapStoreToState(mapping);
-type StoreState = typeof _StoreState;
-const storeGroup = new CQRSStoreGroup(mapping);
+});
 // Context
 const context = new Context({
     dispatcher,
@@ -112,7 +108,7 @@ const functionalUseCase = (context: FunctionalUseCaseContext) => {
 };
 // execute - functional execute with ArgT
 context.useCase(functionalUseCase).execute<functionUseCaseArgs>("1").then(() => {
-    const state = context.getState<StoreState>();
+    const state = context.getState();
     console.log(state.aState.a);
     console.log(state.bState.b);
 });
@@ -123,7 +119,7 @@ context.useCase(functionalUseCase).execute("value").then(() => {
 
 // execute: usecase with T
 context.useCase(parentUseCase).execute<ParentUseCaseArgs>("value").then(() => {
-    const state = context.getState<StoreState>();
+    const state = context.getState();
     console.log(state.aState.a);
     console.log(state.bState.b);
 }).catch((error: Error) => {

--- a/test/typescript/almin-test.ts
+++ b/test/typescript/almin-test.ts
@@ -1,7 +1,6 @@
 import {
     Context,
     Store,
-    StoreGroup,
     Dispatcher,
     UseCase,
     Payload,
@@ -10,7 +9,9 @@ import {
     CompletedPayload,
     ErrorPayload,
     DispatcherPayloadMeta,
-    FunctionalUseCaseContext
+    FunctionalUseCaseContext,
+    MapStoreToState,
+    CQRSStoreGroup
 } from "../../src/index";
 // Dispatcher
 const dispatcher = new Dispatcher();
@@ -53,15 +54,14 @@ class BStore extends Store<BState> {
         };
     }
 }
-// StoreGroup
-interface StoreState {
-    A: AState;
-    B: BState;
-}
-const storeGroup = new StoreGroup([
-    new AStore(),
-    new BStore()
-]);
+const mapping = {
+    A: new AStore(),
+    B: new BStore()
+};
+// Type hacking
+const _StoreState = MapStoreToState(mapping);
+type StoreState = typeof _StoreState;
+const storeGroup = new CQRSStoreGroup(mapping);
 // Context
 const context = new Context({
     dispatcher,

--- a/test/typescript/almin-test.ts
+++ b/test/typescript/almin-test.ts
@@ -55,8 +55,8 @@ class BStore extends Store<BState> {
     }
 }
 const mapping = {
-    A: new AStore(),
-    B: new BStore()
+    aState: new AStore(),
+    bState: new BStore()
 };
 // Type hacking
 const _StoreState = MapStoreToState(mapping);
@@ -113,8 +113,8 @@ const functionalUseCase = (context: FunctionalUseCaseContext) => {
 // execute - functional execute with ArgT
 context.useCase(functionalUseCase).execute<functionUseCaseArgs>("1").then(() => {
     const state = context.getState<StoreState>();
-    console.log(state.A.a);
-    console.log(state.B.b);
+    console.log(state.aState.a);
+    console.log(state.bState.b);
 });
 // execute - functional execute without ArgT
 context.useCase(functionalUseCase).execute("value").then(() => {
@@ -124,8 +124,8 @@ context.useCase(functionalUseCase).execute("value").then(() => {
 // execute: usecase with T
 context.useCase(parentUseCase).execute<ParentUseCaseArgs>("value").then(() => {
     const state = context.getState<StoreState>();
-    console.log(state.A.a);
-    console.log(state.B.b);
+    console.log(state.aState.a);
+    console.log(state.bState.b);
 }).catch((error: Error) => {
     console.error(error);
 });


### PR DESCRIPTION
Follow up #165 #163 

**Edit(2017-04-20)**: Change the title to "Make Context#getState explicit"

This PR make `Context#getState` more type safe.

```ts
const storeGroup = new CQRSStoreGroup({
    aState: new AStore(),
    bState: new BStore()
});
// Context
const context = new Context({
    dispatcher,
    store: storeGroup
});
const state = context.getState();
console.log(state.aState.a);
console.log(state.bState.b);
```

Thanks to @kimamula !

----

<del>

I want to add `MapStoreToState` utility function for TypeScript.
It not have actual implementation, but it is a function...
We want to improve this as possible.

```ts
const mapping = {
    A: new AStore(),
    B: new BStore()
};
// Type hacking
const _StoreState = MapStoreToState(mapping);
type StoreState = typeof _StoreState;
const storeGroup = new CQRSStoreGroup(mapping);
// context
const context = new Context({
    dispatcher,
    store: storeGroup
});
// typed state
const state = context.getState<StoreState>();
console.log(state.A.a);
console.log(state.B.b);
```
</del>
----

## Side Notes 📝 

We should resolve Context issue in essentials.
The `Context` issue come from wrapper method.
Wrapper method could not be strong typed.

- `Context#useCase` and `UseCase#execute`
   - #107 
- `Context#getState`
   - https://github.com/almin/almin/pull/165#discussion_r111994984

But, I have no idea about `Context`.
(We will replace it by the other?)

