### PR TITLE
feat(TypeScript): add `StoreToState` utility type converter

### DIFF
--- a/src/UILayer/StoreGroupTypes.ts
+++ b/src/UILayer/StoreGroupTypes.ts
@@ -12,3 +12,28 @@ export type StateMap<T> = {
     // Now, T[P] is State
     [P in keyof T]: T[P]
 };
+
+/**
+ * Utility type function that create state mapping from store mapping.
+ *
+ * DO NOT USE the returned value.
+ * It should be used for typing.
+ *
+ * ## Example
+ *
+ * ```ts
+ * import { StoreGroupTypes } from "almin";
+ * // store mapping
+ * const storeMapping = {
+ *    appState: new AppStore({ appRepository }),
+ *    counterState: new CounterStore({ appRepository })
+ * };
+ * // state mapping
+ * const stateMapping = StoreGroupTypes.StoreToState(storeMapping);
+ * // typeof StoreGroup state
+ * export type AppStoreGroupState = typeof stateMapping;
+ * ```
+ */
+function StoreToState<T>(mapping: StoreMap<T>): StateMap<T> {
+    return mapping as any;
+}

--- a/src/UILayer/StoreGroupTypes.ts
+++ b/src/UILayer/StoreGroupTypes.ts
@@ -34,6 +34,6 @@ export type StateMap<T> = {
  * export type AppStoreGroupState = typeof stateMapping;
  * ```
  */
-function StoreToState<T>(mapping: StoreMap<T>): StateMap<T> {
+export function StoreToState<T>(mapping: StoreMap<T>): StateMap<T> {
     return mapping as any;
 }


### PR DESCRIPTION
Add `StoreToState` function.
This allow to get type of state without `StoreGroup#getState`.