### PR TITLE
feat(UseCase): Fluent style UseCase

### DIFF
--- a/packages/almin/src/Context.ts
+++ b/packages/almin/src/Context.ts
@@ -17,7 +17,6 @@ import { WillExecutedPayload, isWillExecutedPayload } from "./payload/WillExecut
 import { FunctionalUseCaseContext } from "./FunctionalUseCaseContext";
 import { FunctionalUseCase } from "./FunctionalUseCase";
 import { StateMap } from "./UILayer/StoreGroupTypes";
-import { UseCaseLike } from "./UseCaseLike";
 /**
  * Context class provide observing and communicating with **Store** and **UseCase**.
  */
@@ -159,7 +158,7 @@ export class Context<T> {
      * ```
      */
     useCase(useCase: (context: FunctionalUseCaseContext) => Function): UseCaseExecutor<any>;
-    useCase<T extends UseCaseLike>(useCase: T): UseCaseExecutor<T>;
+    useCase<T extends UseCase>(useCase: T): UseCaseExecutor<T>;
     useCase(useCase: any): UseCaseExecutor<any> {
         // instance of UseCase
         if (UseCase.isUseCase(useCase)) {

--- a/packages/almin/src/Context.ts
+++ b/packages/almin/src/Context.ts
@@ -17,7 +17,7 @@ import { WillExecutedPayload, isWillExecutedPayload } from "./payload/WillExecut
 import { FunctionalUseCaseContext } from "./FunctionalUseCaseContext";
 import { FunctionalUseCase } from "./FunctionalUseCase";
 import { StateMap } from "./UILayer/StoreGroupTypes";
-
+import { UseCaseLike } from "./UseCaseLike";
 /**
  * Context class provide observing and communicating with **Store** and **UseCase**.
  */
@@ -158,9 +158,9 @@ export class Context<T> {
      * context.useCase(awesomeUseCase).execute([1, 2, 3]);
      * ```
      */
-    useCase(useCase: (context: FunctionalUseCaseContext) => Function): UseCaseExecutor;
-    useCase(useCase: UseCase): UseCaseExecutor;
-    useCase(useCase: any): UseCaseExecutor {
+    useCase(useCase: (context: FunctionalUseCaseContext) => Function): UseCaseExecutor<any>;
+    useCase<T extends UseCaseLike>(useCase: T): UseCaseExecutor<T>;
+    useCase(useCase: any): UseCaseExecutor<any> {
         // instance of UseCase
         if (UseCase.isUseCase(useCase)) {
             return new UseCaseExecutor({

--- a/packages/almin/src/UseCaseContext.ts
+++ b/packages/almin/src/UseCaseContext.ts
@@ -67,9 +67,9 @@ export class UseCaseContext {
      * }
      * ```
      */
-    useCase(useCase: (context: FunctionalUseCaseContext) => Function): UseCaseExecutor;
-    useCase(useCase: UseCase): UseCaseExecutor;
-    useCase(useCase: any): UseCaseExecutor {
+    useCase(useCase: (context: FunctionalUseCaseContext) => Function): UseCaseExecutor<any>;
+    useCase<T extends UseCase>(useCase: T): UseCaseExecutor<T>;
+    useCase(useCase: any): UseCaseExecutor<any> {
         if (process.env.NODE_ENV !== "production") {
             assert(useCase !== this._dispatcher, `the useCase(${useCase}) should not equal this useCase(${this._dispatcher})`);
         }

--- a/packages/almin/src/UseCaseExecutor.ts
+++ b/packages/almin/src/UseCaseExecutor.ts
@@ -200,7 +200,22 @@ export class UseCaseExecutor<T extends UseCaseLike> {
         return releaseHandler;
     }
 
-    executor(executor: (useCase: T) => any): any {
+    /**
+     *
+     * Similar to `execute()`, but it can use same interface with initialized UseCase.
+     * It means that it is type safe.
+     *
+     * ## Example
+     *
+     * ```js
+     * context.useCase(new MyUseCase())
+     * .executor(useCase => useCase.execute("value"))
+     * .then(() => {
+     *   console.log("test");
+     * });
+     * ```
+     */
+    executor(executor: (useCase: Pick<T, "execute">) => any): any {
         const proxify = (useCase: T, resolve: Function, reject: Function): T => {
             let isExecuted = false;
             return {

--- a/packages/almin/src/UseCaseInstanceMap.ts
+++ b/packages/almin/src/UseCaseInstanceMap.ts
@@ -30,4 +30,4 @@ See also https://almin.js.org/docs/warnings/usecase-is-already-released.html
  * A UseCase will execute and add it to this map.
  * A UseCase was completed and remove it from this map.
  */
-export const UseCaseInstanceMap = new MapLike<UseCaseLike, UseCaseExecutor>();
+export const UseCaseInstanceMap = new MapLike<UseCaseLike, UseCaseExecutor<any>>();

--- a/packages/almin/test/UseCaseExecutor-test.js
+++ b/packages/almin/test/UseCaseExecutor-test.js
@@ -4,9 +4,11 @@ const sinon = require("sinon");
 const assert = require("assert");
 import { UseCaseExecutor } from "../lib/UseCaseExecutor";
 import { CallableUseCase } from "./use-case/CallableUseCase";
+import { ThrowUseCase } from "./use-case/ThrowUseCase";
 import NoDispatchUseCase from "../../almin-logger/test/usecase/NoDispatchUseCase";
 import { UseCase } from "../lib/UseCase";
 import { Dispatcher } from "../lib/Dispatcher";
+
 describe("UseCaseExecutor", function() {
     describe("#executor", () => {
         let consoleErrorStub = null;
@@ -15,6 +17,18 @@ describe("UseCaseExecutor", function() {
         });
         afterEach(() => {
             consoleErrorStub.restore();
+        });
+        it("should catch sync throwing error in UseCase", () => {
+            const dispatcher = new Dispatcher();
+            const executor = new UseCaseExecutor({
+                useCase: new ThrowUseCase(),
+                dispatcher
+            });
+            return executor.executor((useCase) => useCase.execute()).then(() => {
+                throw new Error("SHOULD NOT CALLED");
+            }, (error) => {
+                assert(error instanceof Error, "should be caught error");
+            });
         });
         it("should throw error when pass non-executor function and output console.error", () => {
             const dispatcher = new Dispatcher();
@@ -102,11 +116,13 @@ describe("UseCaseExecutor", function() {
                 value: "value"
             };
             const dispatcher = new Dispatcher();
+
             class SyncUseCase extends UseCase {
                 execute(payload) {
                     this.dispatch(payload);
                 }
             }
+
             const callStack = [];
             const expectedCallStack = [1, 2, 3];
             const executor = new UseCaseExecutor({
@@ -132,6 +148,18 @@ describe("UseCaseExecutor", function() {
         });
     });
     describe("#execute", function() {
+        it("should catch sync throwing error in UseCase", () => {
+            const dispatcher = new Dispatcher();
+            const executor = new UseCaseExecutor({
+                useCase: new ThrowUseCase(),
+                dispatcher
+            });
+            return executor.execute().then(() => {
+                throw new Error("SHOULD NOT CALLED");
+            }, (error) => {
+                assert(error instanceof Error, "should be caught error");
+            });
+        });
         context("when UseCase is sync", function() {
             it("execute is called", function(done) {
                 // given
@@ -140,6 +168,7 @@ describe("UseCaseExecutor", function() {
                     value: "value"
                 };
                 const dispatcher = new Dispatcher();
+
                 class SyncUseCase extends UseCase {
                     // 2
                     execute(payload) {
@@ -147,6 +176,7 @@ describe("UseCaseExecutor", function() {
                         this.dispatch(payload);
                     }
                 }
+
                 // then
                 // 4
                 dispatcher.onDispatch(({ type, value }) => {
@@ -171,6 +201,7 @@ describe("UseCaseExecutor", function() {
                     value: "value"
                 };
                 const dispatcher = new Dispatcher();
+
                 class AsyncUseCase extends UseCase {
                     // 2
                     execute(payload) {
@@ -180,6 +211,7 @@ describe("UseCaseExecutor", function() {
                         });
                     }
                 }
+
                 // then
                 let isCalledUseCase = false;
                 let isCalledDidExecuted = false;

--- a/packages/almin/test/typescript/almin-test.ts
+++ b/packages/almin/test/typescript/almin-test.ts
@@ -132,7 +132,16 @@ context.useCase(parentUseCase).execute("value").then(() => {
     // nope
 });
 // executor
-context.useCase(parentUseCase)
+
+class MyUseCase extends UseCase {
+    execute(value: string) {
+        this.dispatch({
+            type: "ChildUseCase",
+            value
+        });
+    }
+}
+context.useCase(new MyUseCase())
     .executor(useCase => useCase.execute("value"))
     .then(() => {
         console.log("test");

--- a/packages/almin/test/typescript/almin-test.ts
+++ b/packages/almin/test/typescript/almin-test.ts
@@ -131,3 +131,9 @@ context.useCase(parentUseCase).execute<ParentUseCaseArgs>("value").then(() => {
 context.useCase(parentUseCase).execute("value").then(() => {
     // nope
 });
+// executor
+context.useCase(parentUseCase)
+    .executor(useCase => useCase.execute("value"))
+    .then(() => {
+        console.log("test");
+    });

--- a/packages/almin/test/use-case/CallableUseCase.js
+++ b/packages/almin/test/use-case/CallableUseCase.js
@@ -1,0 +1,16 @@
+// MIT © 2017 azu
+"use strict";
+import { UseCase } from "../../lib/UseCase";
+/*
+ * This UseCase is helper for testing
+ */
+export class CallableUseCase extends UseCase {
+    constructor() {
+        super();
+        this.isExecuted = false;
+    }
+
+    execute() {
+        this.isExecuted = true;
+    }
+}

--- a/packages/almin/test/use-case/ThrowUseCase.js
+++ b/packages/almin/test/use-case/ThrowUseCase.js
@@ -1,0 +1,9 @@
+// LICENSE : MIT
+"use strict";
+import { UseCase } from "../../lib/UseCase";
+export class ThrowUseCase extends UseCase {
+    execute() {
+        // throw Error insteadof returing rejected promise
+        throw new Error("error");
+    }
+}

--- a/perf/benchmark/almin-0.12.js
+++ b/perf/benchmark/almin-0.12.js
@@ -1,0 +1,47 @@
+// MIT © 2017 azu
+"use strict";
+const { Dispatcher, Context, Store, StoreGroup, UseCase } = require("almin-0.12");
+
+module.exports = {
+    createContext(stores){
+        const storeMappings = stores.reduce((t, store) => {
+            t[store.name] = store;
+            return t;
+        }, {})
+        return new Context({
+            dispatcher: new Dispatcher(),
+            store: new StoreGroup(storeMappings)
+        });
+    },
+    createUseCase(state){
+        class MyUseCase extends UseCase {
+            execute() {
+                this.dispatch({
+                    type: "update",
+                    body: state
+                });
+            }
+        }
+        return new MyUseCase();
+    },
+    createStore(name){
+        class TestStore extends Store {
+            constructor() {
+                super();
+                this.name = name;
+                this.state = null
+            }
+
+            receivePayload(payload) {
+                if (payload.type === "update") {
+                    this.setState(payload.body);
+                }
+            }
+
+            getState() {
+                return this.state;
+            }
+        }
+        return new TestStore();
+    }
+};

--- a/perf/benchmark/index.js
+++ b/perf/benchmark/index.js
@@ -1,8 +1,11 @@
 "use strict";
 const bench = require("./src/index");
 const AlminVersions = {
+    "current": require("./almin-current"),
+    "0.12": require("./almin-0.12"),
     "0.9": require("./almin-0.9"),
-    "current": require("./almin-current")};
+};
 bench(AlminVersions, (benchmark) => {
     console.log(benchmark.join("\n"));
+    console.log('Fastest is ' + benchmark.filter('fastest').map('name'));
 });

--- a/perf/benchmark/pacakges/almin-0.12/index.js
+++ b/perf/benchmark/pacakges/almin-0.12/index.js
@@ -1,0 +1,3 @@
+// MIT © 2017 azu
+"use strict";
+module.exports = require("almin");

--- a/perf/benchmark/pacakges/almin-0.12/package.json
+++ b/perf/benchmark/pacakges/almin-0.12/package.json
@@ -1,15 +1,14 @@
 {
   "private":true,
-  "name": "almin-0.9",
+  "name": "almin-0.12",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "azu",
   "license": "MIT",
   "dependencies": {
-    "almin": "^0.9.0"
+    "almin": "^0.12.0"
   }
 }

--- a/perf/benchmark/package.json
+++ b/perf/benchmark/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "almin": "^0.12.1",
     "almin-0.9": "file:pacakges/almin-0.9",
+    "almin-0.12": "file:pacakges/almin-0.12",
     "json2csv": "^3.7.3",
     "lodash.range": "^3.2.0",
     "p-queue": "^1.0.0"

--- a/perf/benchmark/src/index.js
+++ b/perf/benchmark/src/index.js
@@ -18,7 +18,8 @@ if (typeof window == 'object') {
  */
 module.exports = function(AlminVersions, done) {
     const suite = new Suite();
-    Object.keys(AlminVersions).forEach(version => {
+    // randomize for equality
+    _.shuffle(Object.keys(AlminVersions)).forEach(version => {
         suite.add(version, function(deferred) {
             task(AlminVersions[version], (error) => {
                 if (error) {

--- a/perf/benchmark/yarn.lock
+++ b/perf/benchmark/yarn.lock
@@ -50,12 +50,17 @@ align-text@^0.1.1, align-text@^0.1.3:
     longest "^1.0.1"
     repeat-string "^1.5.2"
 
+"almin-0.12@file:pacakges/almin-0.12":
+  version "1.0.0"
+  dependencies:
+    almin "^0.12.0"
+
 "almin-0.9@file:pacakges/almin-0.9":
   version "1.0.0"
   dependencies:
     almin "^0.9.0"
 
-almin@^0.12.1:
+almin@^0.12.0, almin@^0.12.1:
   version "0.12.3"
   resolved "https://registry.yarnpkg.com/almin/-/almin-0.12.3.tgz#418eb7be970b3978954bac91128d13f073270f36"
   dependencies:


### PR DESCRIPTION
Fluent style UseCase https://github.com/almin/almin/issues/193

- Make exist `execute()` catchable(try-catch) that use `executor` method.
- `executor` method always catch sync error and async error(promise).