### PR TITLE
fix(almin): fix warning message format

### DIFF
--- a/packages/almin/src/FunctionalUseCase.ts
+++ b/packages/almin/src/FunctionalUseCase.ts
@@ -14,25 +14,12 @@ const getFunctionalExecute = (functionalUseCase: UseCaseArgs, context: Functiona
     try {
         const execute = functionalUseCase(context);
         if (process.env.NODE_ENV !== "production") {
-            console.error("Wrong Functional UseCase:", functionalUseCase);
-            const message = `Functional UseCase should return executor function.
-Example:
-    
-    const useCase = ({ dispatcher }) => {
-        return (args) => {
-            // execute
-        }
-    };
-    
-    context.useCase(useCase).execute("args");
-`;
-            assert.ok(typeof execute, message)
+            assert.ok(typeof execute === "function", "Functional UseCase should return a executor function.");
         }
         return execute;
     } catch (error) {
         if (process.env.NODE_ENV !== "production") {
-            console.error("Wrong Functional UseCase:", functionalUseCase,
-                `Functional UseCase should return executor function.
+            console.error(`Warning(UseCase): This is wrong Functional UseCase.
 Example:
     
     const useCase = ({ dispatcher }) => {

--- a/packages/almin/src/UILayer/StoreGroup.ts
+++ b/packages/almin/src/UILayer/StoreGroup.ts
@@ -74,7 +74,7 @@ const warningStateIsImmutable = (prevState: any, nextState: any, store: Store, c
     if (isChangingStore) {
         const isStateChanged = shouldStateUpdate(prevState, nextState);
         if (!isStateChanged) {
-            console.warn(`Store(${store.name}) does call emitChange(). 
+            console.error(`Warning(Store): ${store.name} does call emitChange(). 
 But, this store's state is not changed.
 Store's state should be immutable value.
 Prev State:`, prevState, `Next State:`, nextState
@@ -94,7 +94,7 @@ Prev State:`, prevState, `Next State:`, nextState
     const isStatePropertyChanged = prevState !== nextState;
     const isStateChangedButShouldNotUpdate = isStatePropertyChanged && !shouldStateUpdate(prevState, nextState);
     if (isStateChangedButShouldNotUpdate) {
-        console.warn(`${store.name}#state property is changed, but this change does not reflect to view.
+        console.error(`Warning(Store): ${store.name}#state property is changed, but this change does not reflect to view.
 Because, ${store.name}#shouldStateUpdate(prevState, store.state) has returned **false**.
 It means that the variance is present between store's state and shouldStateUpdate.
 You should update the state vis \`Store#setState\` method.

--- a/packages/almin/src/UseCaseExecutor.ts
+++ b/packages/almin/src/UseCaseExecutor.ts
@@ -17,7 +17,7 @@ import { Payload } from "./payload/Payload";
  * @private
  */
 const warningUseCaseIsAlreadyReleased = (parentUseCase: UseCaseLike, useCase: UseCaseLike, payload: Payload, meta: DispatcherPayloadMeta) => {
-    console.warn(`${useCase.name}'s parent UseCase(${parentUseCase.name}) is already released.
+    console.error(`Warning(UseCase): ${useCase.name}'s parent UseCase(${parentUseCase.name}) is already released.
 This UseCase(${useCase.name}) will not work correctly.
 https://almin.js.org/docs/warnings/usecase-is-already-released.html
 `, payload, meta);

--- a/packages/almin/test/FunctionalUseCase-test.js
+++ b/packages/almin/test/FunctionalUseCase-test.js
@@ -1,37 +1,48 @@
 // LICENSE : MIT
 "use strict";
-const assert = require("power-assert");
+const assert = require("assert");
 const sinon = require("sinon");
 import { UseCase } from "../lib/UseCase";
 import { createEchoStore } from "./helper/EchoStore";
 import { Dispatcher } from "../lib/Dispatcher";
-import { Store } from "../lib/Store";
 import { Context } from "../lib/Context";
-import { UseCaseContext } from "../lib/UseCaseContext";
 
 describe("FunctionalUseCase", function() {
-    context("warning", () => {
-        class WriteToTextlintrcUseCase extends UseCase {
-            static create() {
-                return new this();
-            }
+    let consoleErrorStub = null;
+    beforeEach(() => {
+        consoleErrorStub = sinon.stub(console, "error");
+    });
+    afterEach(() => {
+        consoleErrorStub.restore();
+    });
+    context("When passing wrong functional UseCase", () => {
+        it("should show warning and throw Error", () => {
+            class WriteToTextlintrcUseCase extends UseCase {
+                static create() {
+                    return new this();
+                }
 
-            constructor() {
-                super();
-            }
+                constructor() {
+                    super();
+                }
 
-            execute() {
+                execute() {
+                }
             }
-        }
-        const dispatcher = new Dispatcher();
-        const context = new Context({
-            dispatcher,
-            store: createEchoStore({ echo: { "a": "a" } })
+            const dispatcher = new Dispatcher();
+            const context = new Context({
+                dispatcher,
+                store: createEchoStore({ echo: { "a": "a" } })
+            });
+            assert.throws(() => {
+                context.useCase(WriteToTextlintrcUseCase.create).execute();
+                //                                            ~~
+                //                                         missing call ()
+            }, Error);
+            // assert warning message
+            assert(consoleErrorStub.called);
+            const warningMessage = consoleErrorStub.getCalls()[0].args[0];
+            assert(warningMessage.indexOf("Warning(UseCase): This is wrong Functional UseCase.") !== -1, warningMessage);
         });
-        assert.throws(() => {
-            context.useCase(WriteToTextlintrcUseCase.create).execute();
-            //                                            ~~
-            //                                         missing call ()
-        }, Error);
     });
 });

--- a/packages/almin/test/StoreGroup-test.js
+++ b/packages/almin/test/StoreGroup-test.js
@@ -756,12 +756,12 @@ describe("StoreGroup", function() {
             });
         });
         context("warning", () => {
-            let consoleWarnStub = null;
+            let consoleErrorStub = null;
             beforeEach(() => {
-                consoleWarnStub = sinon.stub(console, "warn");
+                consoleErrorStub = sinon.stub(console, "error");
             });
             afterEach(() => {
-                consoleWarnStub.restore();
+                consoleErrorStub.restore();
             });
             it("should check that a Store returned state immutability", function() {
                 const store = createStore({ name: "AStore" });
@@ -770,7 +770,7 @@ describe("StoreGroup", function() {
                 });
                 // When the store is not changed, but call emitChange
                 store.emitChange();
-                assert.ok(consoleWarnStub.calledOnce);
+                assert.ok(consoleErrorStub.calledOnce);
             });
             it("should check that a Store's state is changed but shouldStateUpdate return false", function() {
                 class AStore extends Store {
@@ -803,7 +803,7 @@ describe("StoreGroup", function() {
                     };
                 };
                 return context.useCase(useCase).execute().then(() => {
-                    assert.ok(consoleWarnStub.calledOnce);
+                    assert.ok(consoleErrorStub.calledOnce);
                 });
             });
         });

--- a/packages/almin/test/UseCase-test.js
+++ b/packages/almin/test/UseCase-test.js
@@ -197,12 +197,12 @@ describe("UseCase", function() {
 
          */
         context("when child is completed after parent did completed", function() {
-            let consoleWarnStub = null;
+            let consoleErrorStub = null;
             beforeEach(() => {
-                consoleWarnStub = sinon.stub(console, "warn");
+                consoleErrorStub = sinon.stub(console, "error");
             });
             afterEach(() => {
-                consoleWarnStub.restore();
+                consoleErrorStub.restore();
             });
             it("should not delegate dispatch to parent -> dispatcher and show warning", function(done) {
                 const childPayload = {
@@ -213,9 +213,9 @@ describe("UseCase", function() {
                     // childPayload should not be delegated to dispatcher(root)
                     assert(dispatchedPayloads.indexOf(childPayload) === -1);
                     // insteadof of it, should be display warning messages
-                    assert(consoleWarnStub.called);
-                    const warningMessage = consoleWarnStub.getCalls()[0].args[0];
-                    assert(/UseCase.*?is already released/.test(warningMessage), warningMessage);
+                    assert(consoleErrorStub.called);
+                    const warningMessage = consoleErrorStub.getCalls()[0].args[0];
+                    assert(/Warning\(UseCase\):.*?is already released/.test(warningMessage), warningMessage);
                     done();
                 };
                 class ChildUseCase extends UseCase {


### PR DESCRIPTION
fix warning style

use `console.error`  for stack trace

- https://github.com/facebook/react/issues/4216
- https://github.com/BerkeleyTrue/warning
- https://github.com/facebook/fbjs/pull/183