### PR TITLE
Fix 'unused function argument' in StoreGroup, Context

### DIFF
--- a/packages/almin/type-definitions/index.js.flow
+++ b/packages/almin/type-definitions/index.js.flow
@@ -30,6 +30,7 @@ declare export class DispatcherPayloadMeta {
 }
 
 declare export class StoreGroup extends Dispatcher {
+    constructor(stateStoreMapping: {[string]: Store}): void;
     getState(): Object;
     emitChange(): void;
     onChange(handler: (stores: Array<Store>) => mixed): Function;
@@ -37,6 +38,7 @@ declare export class StoreGroup extends Dispatcher {
 }
 
 declare export class Context {
+    constructor({ dispatcher: Dispatcher, store: Store|StoreGroup }): void;
     getState(): mixed;
     onChange(onChangeHandler: (changingStores: Array<Store>) => mixed): Function;
     useCase(useCase: UseCase): UseCaseExecutor;


### PR DESCRIPTION
I used almin with flowtype.  
Flowtype error occured in Context#constructor and StoreGroup#constructor.

[source/javascripts/main.js:11](https://github.com/Leko/WEB-EGG/tree/master/source/javascripts/main.js#L11)

```
                                    v
 11: const appContext = new Context({
 12:   dispatcher,
 13:   store: AppStoreGroup.create()
 14: })
     ^ unused function argument
       v-----------------------------
   38: declare export class Context {
   39:     getState(): mixed;
   40:     onChange(onChangeHandler: (changingStores: Array<Store>) => mixed): Function;
  ...:
   48: }
       ^ default constructor expects no arguments. See: node_modules/almin/lib/index.js.flow:38
```

---

[source/javascripts/store/AppStoreGroup.js:8](https://github.com/Leko/WEB-EGG/tree/master/source/javascripts/store/AppStoreGroup.js#L8)

```
                               v
  8:     return new StoreGroup({
  9:       postState: new PostStore({ postListRepository })
 10:     })
         ^ unused function argument
       v----------------------------------
  648: declare class events$EventEmitter {
  649:   // deprecated
  650:   static listenerCount(emitter: events$EventEmitter, event: string): number;
  ...:
  665: }
       ^ default constructor expects no arguments. See lib: /private/tmp/flow/flowlib_2b201df0/node.js:648
```

I fixed these errors.