### PR TITLE
test(almin): Remove IE9/IE10 from E2E Tests

### DIFF
--- a/packages/almin/.zuul.yml
+++ b/packages/almin/.zuul.yml
@@ -4,7 +4,7 @@ scripts:
   - https://unpkg.com/console-polyfill
 browsers:
   - name: internet explorer
-    version: 9..latest
+    version: 11..latest
   - name: microsoftedge
     version: latest
   - name: safari


### PR DESCRIPTION
BREAKING CHANGE: Drop IE9/IE10 support

close #168 