### PR TITLE
feat(almin-logger): support almin 0.13.x and transaction

### DIFF
--- a/.textlintrc
+++ b/.textlintrc
@@ -4,7 +4,9 @@
       "allow": [
         "execute",
         "executed",
-        "execution"
+        "execution",
+        "failure",
+        "pros"
       ]
     },
     "no-dead-link": true,

--- a/examples/shopping-cart/README.md
+++ b/examples/shopping-cart/README.md
@@ -12,8 +12,8 @@ Original example from:
 
     # client-side rendering mode
     npm start
+    open http://localhost:8080/
     # server-side rendering mode
-    npm run watch
     npm run start:ssr # Run after generated build/server.js 
     open http://localhost:3000/server
 

--- a/examples/shopping-cart/package.json
+++ b/examples/shopping-cart/package.json
@@ -8,9 +8,11 @@
   },
   "scripts": {
     "clean": "rimraf public/build build/ && mkdirp public/build",
-    "start": "webpack-dev-server --hot --content-base public/ --open",
-    "start:ssr": "node build/server.js",
+    "start": "webpack-dev-server --hot --content-base public/",
+    "start:ssr": "npm run build:ssr && npm run server:ssr",
+    "server:ssr": "node build/server.js",
     "build": "NODE_ENV=production webpack -p",
+    "build:ssr": "NODE_ENV=production webpack --config webpack.server.config.js -p",
     "watch": "NODE_ENV=development webpack -d -w",
     "test": "mocha",
     "ci": "npm test"
@@ -18,7 +20,7 @@
   "author": "azu",
   "license": "MIT",
   "dependencies": {
-    "almin": "^0.12.1",
+    "almin": "^0.13.1",
     "almin-logger": "^4.1.0",
     "almin-react-container": "^0.2.2",
     "power-assert": "^1.4.2",

--- a/examples/shopping-cart/webpack.server.config.js
+++ b/examples/shopping-cart/webpack.server.config.js
@@ -1,12 +1,17 @@
 const path = require("path");
 
-module.exports = {
-    entry: "./src/index.js",
+const client = require("./webpack.config");
+const server = {
+    entry: "./src/server-index.js",
     devtool: process.env.WEBPACK_DEVTOOL || "source-map",
     output: {
-        path: path.join(__dirname, "public", "build"),
-        publicPath: "/build/",
-        filename: "bundle.js"
+        path: path.join(__dirname, "build"),
+        filename: "server.js"
+    },
+    target: "node",
+    node: {
+        __filename: false,
+        __dirname: false
     },
     module: {
         rules: [
@@ -21,3 +26,4 @@ module.exports = {
         ]
     }
 };
+module.exports = [client, server];

--- a/packages/almin-logger/README.md
+++ b/packages/almin-logger/README.md
@@ -1,6 +1,6 @@
 # almin-logger [![Build Status](https://travis-ci.org/almin/almin.svg?branch=master)](https://travis-ci.org/almin/almin)
 
-Logger class for [Almin.js](https://github.com/azu/almin "Almin.js")
+Logger class for [Almin.js](https://github.com/almin/almin "Almin.js")
 
 ![logger](https://monosnap.com/file/AqRVq3UAah8riczytsgXHxGb50fwz2.png)
 
@@ -11,6 +11,12 @@ Logger class for [Almin.js](https://github.com/azu/almin "Almin.js")
 - Changed log of Store
 - Nesting log support if the browser support`console.groupCollapsed`.
 - Async(by default) and Sync logger
+
+## Mark meaning
+
+- :rocket: Transaction
+- :bookmark: A group like UseCase
+- :x: A group that include failure result
 
 ## Installation
 

--- a/packages/almin-logger/package.json
+++ b/packages/almin-logger/package.json
@@ -36,7 +36,7 @@
     "log"
   ],
   "devDependencies": {
-    "almin": "^0.10.0",
+    "almin": "^0.13.0",
     "babel-cli": "^6.7.7",
     "babel-loader": "^6.2.10",
     "babel-plugin-add-module-exports": "^0.2.1",
@@ -52,7 +52,7 @@
     "zuul": "^3.10.1"
   },
   "peerDependencies": {
-    "almin": ">= 0.10.0"
+    "almin": ">= 0.13.0"
   },
   "dependencies": {
     "map-like": "^2.0.0"

--- a/packages/almin-logger/src/SyncLogger.js
+++ b/packages/almin-logger/src/SyncLogger.js
@@ -62,18 +62,18 @@ export default class SyncLogger extends EventEmitter {
             const startTimeStamp = this._logMap[useCase.name];
             const takenTime = meta.timeStamp - startTimeStamp;
             this.logger.log(`${useCase.name} is completed`);
-            this.logger.info("Take time(ms): " + takenTime);
+            this.logger.info(`Take time(ms): ${takenTime}`);
             this.logger.groupEnd(useCase.name);
             this.emit(AlminLogger.Events.output);
         };
         // release handler
         this._releaseHandlers = [
             context.onChange(onChange),
-            context.onDispatch(onDispatch),
-            context.onWillExecuteEachUseCase(onWillExecuteEachUseCase),
-            context.onDidExecuteEachUseCase(onDidExecuteEachUseCase),
-            context.onCompleteEachUseCase(onCompleteUseCase),
-            context.onErrorDispatch(onErrorHandler)
+            context.events.onDispatch(onDispatch),
+            context.events.onWillExecuteEachUseCase(onWillExecuteEachUseCase),
+            context.events.onDidExecuteEachUseCase(onDidExecuteEachUseCase),
+            context.events.onCompleteEachUseCase(onCompleteUseCase),
+            context.events.onErrorDispatch(onErrorHandler)
         ];
     }
 

--- a/packages/almin-logger/src/log/LogGroup.js
+++ b/packages/almin-logger/src/log/LogGroup.js
@@ -4,10 +4,12 @@ export default class LogGroup {
     /**
      * @type {string} title
      * @type {string} [useCaseName]
+     * @type {boolean} [isTransaction]
      */
-    constructor({ title, useCaseName }) {
+    constructor({ title, useCaseName, isTransaction }) {
         this.title = title;
         this.useCaseName = useCaseName;
+        this.isTransaction = isTransaction || false;
         /**
          * @type  {LogChunk|LogGroup[]}
          * @private

--- a/packages/almin-logger/test/AsyncLogger-test.js
+++ b/packages/almin-logger/test/AsyncLogger-test.js
@@ -19,6 +19,8 @@ import ErrorUseCase from "./usecase/ErrorUseCase";
 import WrapUseCase from "./usecase/WrapUseCase";
 import DispatchUseCase from "./usecase/DispatchUseCase";
 import { ParentUseCase, ChildUseCase } from "./usecase/NestingUseCase";
+import { createStore } from "./store/create-store";
+
 describe("AsyncLogger", function() {
     describe("#addLog", () => {
         it("should add current LogGroups", () => {
@@ -28,7 +30,7 @@ describe("AsyncLogger", function() {
             });
             const dispatcher = new Dispatcher();
             const useCase = new WrapUseCase();
-            const store = new Store();
+            const store = createStore();
             const context = new Context({
                 store,
                 dispatcher
@@ -63,7 +65,7 @@ describe("AsyncLogger", function() {
         });
         const dispatcher = new Dispatcher();
         const useCase = new DispatchUseCase();
-        const store = new Store();
+        const store = createStore();
         const context = new Context({
             store,
             dispatcher
@@ -113,7 +115,7 @@ describe("AsyncLogger", function() {
                 console: consoleMock
             });
             const context = new Context({
-                store: new Store(),
+                store: createStore(),
                 dispatcher: new Dispatcher()
             });
             logger.startLogging(context);
@@ -150,7 +152,7 @@ describe("AsyncLogger", function() {
             console: consoleMock
         });
         const dispatcher = new Dispatcher();
-        const store = new Store();
+        const store = createStore();
         const context = new Context({
             store,
             dispatcher
@@ -185,7 +187,7 @@ describe("AsyncLogger", function() {
         const logger = new AsyncLogger({
             console: consoleMock
         });
-        const store = new Store();
+        const store = createStore();
         const dispatcher = new Dispatcher();
         const useCase = new NoDispatchUseCase();
         const context = new Context({
@@ -215,7 +217,7 @@ describe("AsyncLogger", function() {
             console: consoleMock
         });
         const dispatcher = new Dispatcher();
-        const store = new Store();
+        const store = createStore();
         const context = new Context({
             store,
             dispatcher

--- a/packages/almin-logger/test/SyncLogger-test.js
+++ b/packages/almin-logger/test/SyncLogger-test.js
@@ -6,6 +6,8 @@ import SyncLogger from "../src/SyncLogger";
 import AlminLogger from "../src/AlminLogger";
 import ConsoleMock from "./helper/ConsoleMock";
 import NoDispatchUseCase from "./usecase/NoDispatchUseCase";
+import { createStore } from "./store/create-store";
+
 describe("SyncLogger", function() {
     it("should output", function(done) {
         const consoleMock = ConsoleMock.create();
@@ -13,7 +15,7 @@ describe("SyncLogger", function() {
             console: consoleMock
         });
         const dispatcher = new Dispatcher();
-        const store = new Store();
+        const store = createStore();
         const context = new Context({
             store,
             dispatcher

--- a/packages/almin-logger/test/store/create-store.js
+++ b/packages/almin-logger/test/store/create-store.js
@@ -1,0 +1,13 @@
+// MIT © 2017 azu
+"use strict";
+import { Store } from "almin";
+
+export const createStore = () => {
+    class TestStore extends Store {
+        getState() {
+            return {};
+        }
+    }
+
+    return new TestStore();
+};


### PR DESCRIPTION
BREAKING CHANGE: almin-logger depended on almin 0.13.x
Almin-logger use `context.events.on*` events.
These events is introduced on almin 0.13.x

![image](https://user-images.githubusercontent.com/19714/28243218-fa70f9be-69fc-11e7-8a57-2a81250de151.png)

