### PR TITLE
fix(almin): tryUpdateState should be called before actual finished

### DIFF
--- a/packages/almin/src/UILayer/StoreGroup.ts
+++ b/packages/almin/src/UILayer/StoreGroup.ts
@@ -345,14 +345,18 @@ But, ${store.name}#getState() was called.`
             }
             this.tryUpdateState(payload, meta);
         } else if (isCompletedPayload(payload) && meta.useCase && meta.isUseCaseFinished) {
-            this._workingUseCaseMap.delete(meta.useCase.id);
             // if the useCase is already finished, doesn't emitChange in CompletedPayload
             // In other word, If the UseCase that return non-promise value, doesn't emitChange in CompletedPayload
             if (this._finishedUseCaseMap.has(meta.useCase.id)) {
                 this._finishedUseCaseMap.delete(meta.useCase.id);
+                // clean up about this UseCase
+                this._workingUseCaseMap.delete(meta.useCase.id);
                 return;
             }
+            // if the UseCase#execute has async behavior, try to update before actual completed
             this.tryUpdateState(payload, meta);
+            // Now, this UseCase actual finish
+            this._workingUseCaseMap.delete(meta.useCase.id);
         }
     }
 
@@ -415,6 +419,7 @@ But, ${store.name}#getState() was called.`
                 const prevState = this._stateCacheMap.get(store);
                 const nextState = store.getState();
                 // mark `store` as `emitChange`ed store in a UseCase life-cycle
+                console.log("mark", prevState, nextState);
                 this.storeGroupEmitChangeChecker.mark(store, prevState, nextState);
                 if (this.isStrictMode) {
                     // warning if this store is not allowed update at the time

--- a/packages/almin/src/UILayer/StoreGroupEmitChangeChecker.ts
+++ b/packages/almin/src/UILayer/StoreGroupEmitChangeChecker.ts
@@ -47,10 +47,10 @@ const warningIfStatePropertyIsModifiedDirectly = (store: Store, prevState: any, 
     }
     const isStateReferenceReplaced = prevState !== nextState;
     const isStateUpdated = shouldStateUpdate(store, prevState, nextState);
-    const isStateChangedButShouldNotUpdate = isStateReferenceReplaced && !isStateUpdated;
-    if (isStateChangedButShouldNotUpdate) {
+    const isStateReplacedButShouldNotUpdate = isStateReferenceReplaced && !isStateUpdated;
+    if (isStateReplacedButShouldNotUpdate) {
         console.error(
-            `Warning(Store): ${store.name}#state property is replace by difference value, but this change **does not** reflect to view.
+            `Warning(Store): ${store.name}#state property is replaced by different value, but this change **does not** reflect to view.
 Because, ${store.name}#shouldStateUpdate(prevState, store.state) has returned **false**.
 
 It means that the variance is present between ${store.name}#state property and shouldStateUpdate.

--- a/packages/almin/test/Context-test.js
+++ b/packages/almin/test/Context-test.js
@@ -130,8 +130,8 @@ describe("Context", function() {
                 done();
             });
             // catch multiple changes at one time
-            aStore.updateState({ a: 1 });
-            bStore.updateState({ b: 1 });
+            aStore.mutableStateWithoutEmit({ a: 1 });
+            bStore.mutableStateWithoutEmit({ b: 1 });
             aStore.emitChange();
         });
     });

--- a/packages/almin/test/Context-transaction-test.js
+++ b/packages/almin/test/Context-transaction-test.js
@@ -7,6 +7,7 @@ import { createStore } from "./helper/create-new-store";
 import { NoDispatchUseCase } from "./use-case/NoDispatchUseCase";
 import { DispatchUseCase } from "./use-case/DispatchUseCase";
 import { ThrowUseCase } from "./use-case/ThrowUseCase";
+import { createUpdatableStoreWithUseCase } from "./helper/create-update-store-usecase";
 
 /**
  * create a Store that can handle receivePayload
@@ -31,26 +32,29 @@ const createReceivePayloadStore = receivePayloadHandler => {
 };
 describe("Context#transaction", () => {
     it("should collect up StoreGroup commit", function() {
-        const aStore = createStore({ name: "AStore" });
-        const bStore = createStore({ name: "BStore" });
-        const cStore = createStore({ name: "CStore" });
+        const { MockStore: AStore, MockUseCase: AUseCase } = createUpdatableStoreWithUseCase("A");
+        const { MockStore: BStore, MockUseCase: BUseCase } = createUpdatableStoreWithUseCase("B");
+        const { MockStore: CStore, MockUseCase: CUseCase } = createUpdatableStoreWithUseCase("C");
+        const aStore = new AStore();
+        const bStore = new BStore();
+        const cStore = new CStore();
         const storeGroup = new StoreGroup({ a: aStore, b: bStore, c: cStore });
 
-        class ChangeAUseCase extends UseCase {
+        class ChangeAUseCase extends AUseCase {
             execute() {
-                aStore.updateState(1);
+                this.requestUpdateState(1);
             }
         }
 
-        class ChangeBUseCase extends UseCase {
+        class ChangeBUseCase extends BUseCase {
             execute() {
-                bStore.updateState(1);
+                this.requestUpdateState(1);
             }
         }
 
-        class ChangeCUseCase extends UseCase {
+        class ChangeCUseCase extends CUseCase {
             execute() {
-                cStore.updateState(1);
+                this.requestUpdateState(1);
             }
         }
 
@@ -211,7 +215,8 @@ describe("Context#transaction", () => {
     });
 
     it("should meta.transaction is current transaction", function() {
-        const aStore = createStore({ name: "test" });
+        const { MockStore: AStore, MockUseCase: AUseCase } = createUpdatableStoreWithUseCase("A");
+        const aStore = new AStore();
         const storeGroup = new StoreGroup({ a: aStore });
         const dispatcher = new Dispatcher();
         const context = new Context({
@@ -222,11 +227,12 @@ describe("Context#transaction", () => {
             }
         });
 
-        class ChangeAUseCase extends UseCase {
+        class ChangeAUseCase extends AUseCase {
             execute() {
-                aStore.updateState(1);
+                this.requestUpdateState(1);
             }
         }
+
         const transactionName = "My Transaction";
         dispatcher.onDispatch((payload, meta) => {
             assert.deepEqual(meta.transaction, {

--- a/packages/almin/test/DispatcherPayloadMeta-test.js
+++ b/packages/almin/test/DispatcherPayloadMeta-test.js
@@ -8,8 +8,8 @@ import { createStore } from "./helper/create-new-store";
 import { DispatchUseCase } from "./use-case/DispatchUseCase";
 import { ErrorUseCase } from "./use-case/ErrorUseCase";
 import { ParentUseCase } from "./use-case/NestingUseCase";
-import { NoDispatchUseCase } from "./use-case/NoDispatchUseCase";
-import ReturnPromiseUseCase from "./use-case/ReturnPromiseUseCase";
+import { SyncNoDispatchUseCase } from "./use-case/SyncNoDispatchUseCase";
+import { AsyncUseCase } from "./use-case/AsyncUseCase";
 
 describe("DispatcherPayloadMeta", () => {
     describe("onWillExecuteEachUseCase", () => {
@@ -19,7 +19,7 @@ describe("DispatcherPayloadMeta", () => {
                 dispatcher,
                 store: createStore({ name: "test" })
             });
-            const useCase = new NoDispatchUseCase();
+            const useCase = new SyncNoDispatchUseCase();
             let actualMeta = null;
             context.events.onWillExecuteEachUseCase((payload, meta) => {
                 actualMeta = meta;
@@ -61,7 +61,7 @@ describe("DispatcherPayloadMeta", () => {
                 dispatcher,
                 store: createStore({ name: "test" })
             });
-            const useCase = new NoDispatchUseCase();
+            const useCase = new SyncNoDispatchUseCase();
             let actualMeta = null;
             context.events.onDidExecuteEachUseCase((payload, meta) => {
                 actualMeta = meta;
@@ -81,7 +81,7 @@ describe("DispatcherPayloadMeta", () => {
                 dispatcher,
                 store: createStore({ name: "test" })
             });
-            const useCase = new ReturnPromiseUseCase();
+            const useCase = new AsyncUseCase();
             let actualMeta = null;
             context.events.onDidExecuteEachUseCase((payload, meta) => {
                 actualMeta = meta;
@@ -103,7 +103,7 @@ describe("DispatcherPayloadMeta", () => {
                 dispatcher,
                 store: createStore({ name: "test" })
             });
-            const useCase = new NoDispatchUseCase();
+            const useCase = new SyncNoDispatchUseCase();
             let actualMeta = null;
             context.events.onCompleteEachUseCase((payload, meta) => {
                 actualMeta = meta;

--- a/packages/almin/test/StoreGroup-edge-case-test.js
+++ b/packages/almin/test/StoreGroup-edge-case-test.js
@@ -3,10 +3,9 @@
 const assert = require("assert");
 const sinon = require("sinon");
 import { Context, Dispatcher, Store, StoreGroup, UseCase } from "../src/";
-import { NoDispatchUseCase } from "./use-case/NoDispatchUseCase";
-import ReturnPromiseUseCase from "./use-case/ReturnPromiseUseCase";
-import { createStore } from "./helper/create-new-store";
 import { createUpdatableStoreWithUseCase } from "./helper/create-update-store-usecase";
+import { AsyncUseCase } from "./use-case/AsyncUseCase";
+import { SyncNoDispatchUseCase } from "./use-case/SyncNoDispatchUseCase";
 
 describe("StoreGroup edge case", function() {
     describe("when {A,B}Store#emitChange on UseCase is completed", () => {
@@ -71,8 +70,8 @@ describe("StoreGroup edge case", function() {
             context.onChange(() => {
                 count++;
             });
-            return context.useCase(new NoDispatchUseCase()).execute().then(() => {
-                assert(count === 1);
+            return context.useCase(new SyncNoDispatchUseCase()).execute().then(() => {
+                assert.strictEqual(count, 1, "1 onChange by did(Sync UseCase)");
             });
         });
     });
@@ -113,7 +112,7 @@ describe("StoreGroup edge case", function() {
             context.events.onCompleteEachUseCase(() => {
                 callStack.push("complete");
             });
-            return context.useCase(new ReturnPromiseUseCase()).execute().then(() => {
+            return context.useCase(new AsyncUseCase()).execute().then(() => {
                 assert.deepEqual(
                     callStack,
                     [

--- a/packages/almin/test/StoreGroup-edge-case-test.js
+++ b/packages/almin/test/StoreGroup-edge-case-test.js
@@ -8,8 +8,28 @@ import { Store } from "../src/Store";
 import { StoreGroup } from "../src/UILayer/StoreGroup";
 import { NoDispatchUseCase } from "./use-case/NoDispatchUseCase";
 import ReturnPromiseUseCase from "./use-case/ReturnPromiseUseCase";
+import { createStore } from "./helper/create-new-store";
 
 describe("StoreGroup edge case", function() {
+    describe("when {A,B}Store#emitChange on completed Payload", () => {
+        it("should onChange at once", () => {
+            const aStore = createStore({ name: "AStore" });
+            const bStore = createStore({ name: "BStore" });
+            const storeGroup = new StoreGroup({ a: aStore, b: bStore });
+            const context = new Context({
+                dispatcher: new Dispatcher(),
+                store: storeGroup
+            });
+
+            let count = 0;
+            context.onChange(() => {
+                count++;
+            });
+            return context.useCase(new NoDispatchUseCase()).execute().then(() => {
+                assert(count === 1);
+            });
+        });
+    });
     // See https://github.com/almin/almin/issues/179
     describe("when call Store#emitChange in Store#receivePayload", () => {
         it("should not infinity loop", () => {

--- a/packages/almin/test/StoreGroup-test.js
+++ b/packages/almin/test/StoreGroup-test.js
@@ -18,7 +18,7 @@ const createAsyncChangeStoreUseCase = store => {
         execute() {
             return Promise.resolve().then(() => {
                 const newState = { a: {} };
-                store.updateState(newState);
+                store.mutableStateWithoutEmit(newState);
             });
         }
     }
@@ -29,7 +29,7 @@ const createChangeStoreUseCase = store => {
     class ChangeTheStoreUseCase extends UseCase {
         execute() {
             const newState = { a: {} };
-            store.updateState(newState);
+            store.mutableStateWithoutEmit(newState);
         }
     }
 

--- a/packages/almin/test/StoreGroup-test.js
+++ b/packages/almin/test/StoreGroup-test.js
@@ -542,7 +542,6 @@ describe("StoreGroup", function() {
                             this.context.useCase(bUseCase).execute()
                         ]).then(() => {
                             cStore.updateState({ c: 1 });
-                            cStore.emitChange();
                         });
                     }
                 }
@@ -624,7 +623,7 @@ describe("StoreGroup", function() {
                         dispatcher.dispatch(new ExamplePayload());
                     };
                 };
-                const useCaseASync = ({ dispatcher }) => {
+                const useCaseAsync = ({ dispatcher }) => {
                     return () => {
                         dispatcher.dispatch(new ExamplePayload());
                         return Promise.resolve();
@@ -637,6 +636,7 @@ describe("StoreGroup", function() {
                     // Sync UseCase
                     ExamplePayload,
                     DidExecutedPayload,
+                    // CompletedPayload is not called because sync useCase is already finished,
                     // Async UseCase,
                     ExamplePayload,
                     DidExecutedPayload,
@@ -647,7 +647,7 @@ describe("StoreGroup", function() {
                     .useCase(useCaseSync)
                     .execute()
                     .then(() => {
-                        return context.useCase(useCaseASync).execute();
+                        return context.useCase(useCaseAsync).execute();
                     })
                     .then(() => {
                         assert.strictEqual(
@@ -659,7 +659,7 @@ describe("StoreGroup", function() {
                             const ExpectedPayloadClass = expectedReceivedPayloadList[index];
                             assert.ok(
                                 payload instanceof ExpectedPayloadClass,
-                                `${payload} instanceof ${ExpectedPayloadClass}`
+                                `${payload.type} instanceof ${ExpectedPayloadClass}`
                             );
                         });
                     });
@@ -797,7 +797,7 @@ describe("StoreGroup", function() {
     describe("Warning", () => {
         let consoleErrorStub = null;
         beforeEach(() => {
-            consoleErrorStub = sinon.stub(console, "error");
+            consoleErrorStub = sinon.spy(console, "error");
         });
         afterEach(() => {
             consoleErrorStub.restore();
@@ -834,14 +834,6 @@ describe("StoreGroup", function() {
 
                 checkUpdate() {
                     this.setState(Object.assign({}, state));
-                }
-
-                receivePayload() {
-                    // 3. directly state modified
-                    // It test _emitChangeStateCacheMap is pruned
-                    this.state = {
-                        value: "next"
-                    };
                 }
 
                 getState() {
@@ -883,7 +875,7 @@ describe("StoreGroup", function() {
                     assert.equal(
                         consoleErrorStub.callCount,
                         0,
-                        `It should not warn .
+                        `This does call emitChange() warning should not be called.
 init -> next -> init in a execution of UseCase should be valid.
 Something wrong implementation of calling Store#emitChange at multiple`
                     );

--- a/packages/almin/test/UseCaseExecutor-test.js
+++ b/packages/almin/test/UseCaseExecutor-test.js
@@ -2,7 +2,7 @@
 "use strict";
 const sinon = require("sinon");
 const assert = require("assert");
-import { NoDispatchUseCase } from "./use-case/NoDispatchUseCase";
+import { SyncNoDispatchUseCase } from "./use-case/SyncNoDispatchUseCase";
 import { Dispatcher } from "../src/Dispatcher";
 import { UseCase } from "../src/UseCase";
 import { UseCaseExecutor } from "../src/UseCaseExecutor";
@@ -36,7 +36,7 @@ describe("UseCaseExecutor", function() {
         it("should throw error when pass non-executor function and output console.error", () => {
             const dispatcher = new Dispatcher();
             const executor = new UseCaseExecutor({
-                useCase: new NoDispatchUseCase(),
+                useCase: new SyncNoDispatchUseCase(),
                 dispatcher
             });
             return executor.executor(" THIS IS WRONG ").then(
@@ -79,7 +79,7 @@ describe("UseCaseExecutor", function() {
         it("executor(useCase => {}) useCase is actual wrapper object", () => {
             const dispatcher = new Dispatcher();
             const executor = new UseCaseExecutor({
-                useCase: new NoDispatchUseCase(),
+                useCase: new SyncNoDispatchUseCase(),
                 dispatcher
             });
             return executor.executor(useCase => {
@@ -111,7 +111,7 @@ describe("UseCaseExecutor", function() {
         it("should show warning when UseCase#execute twice", () => {
             const dispatcher = new Dispatcher();
             const executor = new UseCaseExecutor({
-                useCase: new NoDispatchUseCase(),
+                useCase: new SyncNoDispatchUseCase(),
                 dispatcher
             });
             return executor

--- a/packages/almin/test/helper/create-new-store.js
+++ b/packages/almin/test/helper/create-new-store.js
@@ -1,6 +1,7 @@
 // MIT © 2017 azu
 "use strict";
 import { Store } from "../../src/Store";
+
 /**
  * This helper is for creating Store
  * @param {string} name
@@ -15,13 +16,25 @@ export function createStore({ name, state }) {
             this.state = state || "value";
         }
 
-        updateState(newState) {
+        /**
+         * Directly modify state
+         */
+        mutableStateWithoutEmit(newState) {
             this.state = newState;
+        }
+
+        /**
+         * setState
+         * @param {*} newState
+         */
+        updateState(newState) {
+            this.setState(newState);
         }
 
         getState() {
             return this.state;
         }
     }
+
     return new MockStore();
 }

--- a/packages/almin/test/helper/create-update-store-usecase.js
+++ b/packages/almin/test/helper/create-update-store-usecase.js
@@ -1,0 +1,59 @@
+// MIT © 2017 azu
+"use strict";
+import { UseCase, Store } from "../../src/index";
+import { shallowEqual } from "shallow-equal-object";
+
+export function createUpdatableStoreWithUseCase(name) {
+    let sharedState = {};
+
+    /**
+     * request state updating function.
+     * The change will be apply on Store#receivePayload
+     * @param {*} newState
+     */
+    const requestUpdateState = newState => {
+        sharedState = newState;
+    };
+
+    /**
+     * This UseCase can update Store via Store#receivePayload
+     */
+    class MockUseCase extends UseCase {
+        constructor() {
+            super();
+            this.name = `${name}UseCase`;
+        }
+
+        /**
+         * Update State
+         * @param {*} newState
+         */
+        requestUpdateState(newState) {
+            requestUpdateState(newState);
+        }
+    }
+
+    class MockStore extends Store {
+        constructor() {
+            super();
+            this.name = `${name}Store`;
+            this.state = {};
+        }
+
+        receivePayload(payload) {
+            if (!shallowEqual(this.state, sharedState)) {
+                this.setState(sharedState);
+            }
+        }
+
+        getState() {
+            return this.state;
+        }
+    }
+
+    return {
+        MockUseCase,
+        MockStore,
+        requestUpdateState
+    };
+}

--- a/packages/almin/test/use-case/AsyncUseCase.js
+++ b/packages/almin/test/use-case/AsyncUseCase.js
@@ -1,0 +1,12 @@
+// MIT © 2017 azu
+"use strict";
+import { UseCase } from "../../src/UseCase";
+
+/**
+ * This is AsyncUseCase and this do not dispatch.
+ */
+export class AsyncUseCase extends UseCase {
+    execute() {
+        return Promise.resolve();
+    }
+}

--- a/packages/almin/test/use-case/ReturnPromiseUseCase.js
+++ b/packages/almin/test/use-case/ReturnPromiseUseCase.js
@@ -1,9 +1,0 @@
-// MIT © 2017 azu
-"use strict";
-import { UseCase } from "../../src/UseCase";
-// async usecase
-export default class ReturnPromiseUseCase extends UseCase {
-    execute() {
-        return Promise.resolve("value");
-    }
-}

--- a/packages/almin/test/use-case/SyncNoDispatchUseCase.js
+++ b/packages/almin/test/use-case/SyncNoDispatchUseCase.js
@@ -1,6 +1,6 @@
 // MIT © 2017 azu
 "use strict";
 import { UseCase } from "../../src/UseCase";
-export class NoDispatchUseCase extends UseCase {
+export class SyncNoDispatchUseCase extends UseCase {
     execute() {}
 }


### PR DESCRIPTION
from #241 

This PR fixes to update on completed payload.

Before:

- When call tryUpdateState on Completed, the useCase is already finished.

After:

- When call tryUpdateState on Completed, the useCase is not finished.
- After tryUpdateState is finished, the useCase is  actually finished.