### PR TITLE
fix(almin): export UseCaseExecutor from index

### DIFF
--- a/packages/almin/src/Context.ts
+++ b/packages/almin/src/Context.ts
@@ -220,7 +220,7 @@ export class Context<T> {
     useCase(useCase: any): UseCaseExecutor<any> {
         const useCaseExecutor = createUseCaseExecutor(useCase, this.dispatcher);
         this.defaultUnitOfWork.open(useCaseExecutor);
-        useCaseExecutor.onComplete(() => {
+        useCaseExecutor.onRelease(() => {
             this.defaultUnitOfWork.close(useCaseExecutor);
         });
         return useCaseExecutor;

--- a/packages/almin/src/UnitOfWork/UnitOfWork.ts
+++ b/packages/almin/src/UnitOfWork/UnitOfWork.ts
@@ -26,7 +26,7 @@ export interface Committable {
 export class UnitOfWork extends EventEmitter {
     private commitments: Commitment[];
     private committable: Committable;
-    private isDisposed: boolean;
+    isDisposed: boolean;
 
     /**
      * @param {Committable} committable it is often StoreGroup

--- a/packages/almin/src/UnitOfWork/UseCaseUnitOfWork.ts
+++ b/packages/almin/src/UnitOfWork/UseCaseUnitOfWork.ts
@@ -48,6 +48,24 @@ export class UseCaseUnitOfWork {
         }
     }
 
+    get isDisposed() {
+        return this.unitOfWork.isDisposed;
+    }
+
+    /**
+     * current queued commitment size
+     */
+    get size() {
+        return this.unitOfWork.size;
+    }
+
+    /**
+     * count of current working useCases
+     */
+    get workingUseCaseCount() {
+        return this.unsubscribeMap.size;
+    }
+
     beginTransaction() {
         this.isTransactionWorking = true;
         const payload = new TransactionBeganPayload(this.name);

--- a/packages/almin/src/index.ts
+++ b/packages/almin/src/index.ts
@@ -4,8 +4,10 @@ export { Dispatcher } from "./Dispatcher";
 export { Store } from "./Store";
 export { StoreGroup } from "./UILayer/StoreGroup";
 export { UseCase } from "./UseCase";
+export { UseCaseExecutor } from "./UseCaseExecutor";
 export { Context } from "./Context";
 export { FunctionalUseCaseContext } from "./FunctionalUseCaseContext";
+// payload
 export { CompletedPayload } from "./payload/CompletedPayload";
 export { DidExecutedPayload } from "./payload/DidExecutedPayload";
 export { Payload } from "./payload/Payload";
@@ -19,4 +21,5 @@ export { DispatcherPayloadMeta } from "./DispatcherPayloadMeta";
 import * as StoreGroupTypes from "./UILayer/StoreGroupTypes";
 export { StoreGroupTypes };
 export { StoreLike } from "./StoreLike";
+export { UseCaseLike } from "./UseCaseLike";
 export { DispatchedPayload } from "./Dispatcher";


### PR DESCRIPTION
BREAKING CHANGE: remove on* handler from UseCaseExecutor.
Use UseCaseExecutor#onDispatch instead of it.

We don't know this handler use-case.

If you want to this, please file new issue.

---

- export `UseCaseExecutor` from index

This is useful for wrapper function of `context.useCase`

```js
/**
 * Extends React.Component for Container.
 * It has executor feature for almin UseCase.
 */
export class BaseContainer<T, P> extends React.Component<T, P> {
    useCase<T extends UseCase>(useCase: T): UseCaseExecutor<T> {
        return appLocator.context.useCase(useCase);
    }
}
```

- https://github.com/azu/faao/blob/master/src/component/container/BaseContainer.ts

fix #206 