### PR TITLE
fix(almin): add warning to no-commit transaction

### DIFF
--- a/packages/almin/src/Context.ts
+++ b/packages/almin/src/Context.ts
@@ -255,6 +255,14 @@ export class Context<T> {
      *
      * ## Notes
      *
+     * ### Transaction should be commit or exit
+     *
+     * Transaction context should be `commit()` or `exit()`.
+     * Because, this check logic avoid to silent failure of transaction.
+     *
+     * And, transaction context should return a promise.
+     * In most case, transaction context should return `transactionContext.useCase(useCase).execute()`.
+     *
      * ### Transaction is not lock system
      *
      * The **transaction** does not lock the store.
@@ -274,8 +282,10 @@ export class Context<T> {
      *
      * ```js
      * context.transaction("No commit transaction", transactionContext => {
-     *      // No commit
-     *      return transactionContext.useCase(new LogUseCase()).execute();
+     *      // No commit - Call `transactionContext.exit()` insteadof `transactionContext.commit()`
+     *      return transactionContext.useCase(new LogUseCase()).execute().then(() => {
+     *          transactionContext.exit();
+     *      });
      * });
      * ```
      *
@@ -317,19 +327,32 @@ Please enable strict mode via \`new Context({ dispatcher, store, options: { stri
             useCase: createUseCaseExecutorAndOpenUoW,
             commit() {
                 unitOfWork.commit();
+            },
+            exit() {
+                unitOfWork.exit();
             }
         };
         unitOfWork.beginTransaction();
         // transactionContext resolve with void
         // unitOfWork automatically close on transactionContext exited
         // by design.
-        return transactionHandler(context).then(
+        const promise = transactionHandler(context);
+        if (!promise) {
+            throw new Error(`transaction context should return promise.
+Transaction should be exited after all useCases have been completed.
+
+For example, following transaction will be exited after SomeUseCase is completed.
+
+context.transaction("transaction", transactionContext => {
+     return transactionContext.useCase(new SomeUseCase()).execute();
+});          
+`);
+        }
+        return promise.then(
             () => {
-                unitOfWork.endTransaction();
                 unitOfWork.release();
             },
             error => {
-                unitOfWork.endTransaction();
                 unitOfWork.release();
                 return Promise.reject(error);
             }

--- a/packages/almin/src/Context.ts
+++ b/packages/almin/src/Context.ts
@@ -257,7 +257,7 @@ export class Context<T> {
      *
      * ### Transaction should be commit or exit
      *
-     * Transaction context should be `commit()` or `exit()`.
+     * Transaction context should be called `commit()` or `exit()`.
      * Because, this check logic avoid to silent failure of transaction.
      *
      * And, transaction context should return a promise.

--- a/packages/almin/src/UnitOfWork/TransactionContext.ts
+++ b/packages/almin/src/UnitOfWork/TransactionContext.ts
@@ -9,5 +9,12 @@ export interface TransactionContext {
 
     useCase(useCase: UseCaseFunction): UseCaseExecutor<FunctionalUseCase>;
 
+    /**
+     * Commit current queued payload.
+     */
     commit: () => void;
+    /**
+     * Exit the transaction without commit.
+     */
+    exit: () => void;
 }

--- a/packages/almin/test/Context-transaction-test.js
+++ b/packages/almin/test/Context-transaction-test.js
@@ -6,9 +6,9 @@ import { DispatcherPayloadMetaImpl } from "../src/DispatcherPayloadMeta";
 import { createStore } from "./helper/create-new-store";
 import { SyncNoDispatchUseCase } from "./use-case/SyncNoDispatchUseCase";
 import { DispatchUseCase } from "./use-case/DispatchUseCase";
-import { ThrowUseCase } from "./use-case/ThrowUseCase";
 import { createUpdatableStoreWithUseCase } from "./helper/create-update-store-usecase";
 import { AsyncUseCase } from "./use-case/AsyncUseCase";
+const sinon = require("sinon");
 
 /**
  * create a Store that can handle receivePayload
@@ -300,6 +300,35 @@ describe("Context#transaction", () => {
                     const [payload, meta] = receivedCommitments[0];
                     assert.ok(payload instanceof Payload);
                     assert.ok(meta instanceof DispatcherPayloadMetaImpl);
+                });
+        });
+    });
+    context("Warning(Transaction):", () => {
+        let consoleErrorStub = null;
+        beforeEach(() => {
+            consoleErrorStub = sinon.stub(console, "error");
+        });
+        afterEach(() => {
+            consoleErrorStub.restore();
+        });
+        it("should be warned when no-commit and no-exit in a transaction", function() {
+            const aStore = createStore({ name: "test" });
+            const storeGroup = new StoreGroup({ a: aStore });
+            const dispatcher = new Dispatcher();
+            const context = new Context({
+                dispatcher,
+                store: storeGroup,
+                options: {
+                    strict: true
+                }
+            });
+            // 1st transaction
+            return context
+                .transaction("transaction", transactionContext => {
+                    return Promise.resolve();
+                })
+                .then(() => {
+                    assert.strictEqual(consoleErrorStub.callCount, 1);
                 });
         });
     });

--- a/packages/almin/test/StoreGroup-test.js
+++ b/packages/almin/test/StoreGroup-test.js
@@ -797,7 +797,7 @@ describe("StoreGroup", function() {
     describe("Warning", () => {
         let consoleErrorStub = null;
         beforeEach(() => {
-            consoleErrorStub = sinon.spy(console, "error");
+            consoleErrorStub = sinon.stub(console, "error");
         });
         afterEach(() => {
             consoleErrorStub.restore();


### PR DESCRIPTION
- Add `transactionContext.exit()` for evincive committment

Following case is invalid


```js
    await appContext.transaction("bootstrap", async (transactionContext) => {
        await transactionContext.useCase(InitializeCustomerUseCase.create()).execute();
        // forget to commit!!!
        // please commit() or exit()!!!
    })

/*
Warning(Transaction): Transaction(${this.name}) should be commit() or exit() at least one. 
If you not want to commit, Please call \`transactionContext.exit()\` at end of transaction.
*/
```

fix #240 
