### PR TITLE
chore(almin): export interface insteadof UseCaseExecutorImpl

### DIFF
--- a/packages/almin/src/UseCaseExecutor.ts
+++ b/packages/almin/src/UseCaseExecutor.ts
@@ -78,15 +78,28 @@ https://almin.js.org/docs/warnings/usecase-is-already-released.html
     );
 };
 
+export interface UseCaseExecutor<T extends UseCaseLike> extends Dispatcher {
+    useCase: T;
+
+    executor(executor: (useCase: Pick<T, "execute">) => any): Promise<void>;
+
+    execute(): Promise<void>;
+
+    execute<T>(args: T): Promise<void>;
+
+    execute(...args: Array<any>): Promise<void>;
+
+    release(): void;
+}
+
 /**
  * `UseCaseExecutor` is a helper class for executing UseCase.
  *
  * You can not create the instance of UseCaseExecutor directory.
  * You can get the instance by `Context#useCase(useCase)`,
  *
- * @private
  */
-export class UseCaseExecutor<T extends UseCaseLike> extends Dispatcher {
+export class UseCaseExecutorImpl<T extends UseCaseLike> extends Dispatcher implements UseCaseExecutor<T> {
     /**
      * A executable useCase
      */
@@ -265,7 +278,7 @@ export class UseCaseExecutor<T extends UseCaseLike> extends Dispatcher {
      * So, Almin return only command result that is success or failure.
      * You should not relay on the data of the command result.
      */
-    executor(executor: (useCase: Pick<T, "execute">) => any): any {
+    executor(executor: (useCase: Pick<T, "execute">) => any): Promise<void> {
         const startingExecutor = (resolve: Function, reject: Function): void => {
             if (typeof executor !== "function") {
                 console.error(
@@ -305,8 +318,15 @@ export class UseCaseExecutor<T extends UseCaseLike> extends Dispatcher {
 
     /**
      * execute UseCase instance.
-     * UseCase is a executable object. it means that has `execute` method.
-     * Notes: UseCaseExecutor doesn't return resolved value by design
+     * UseCase is a executable object that has `execute` method.
+     *
+     * This method invoke UseCase's `execute` method and return a promise<void>.
+     * The promise will be resolved when the UseCase is completed finished.
+     *
+     * ## Notes
+     *
+     * The `execute(arguments)` is shortcut of `executor(useCase => useCase.execute(arguments)`
+     *
      */
     execute(): Promise<void>;
     execute<T>(args: T): Promise<void>;

--- a/packages/almin/src/UseCaseExecutorFactory.ts
+++ b/packages/almin/src/UseCaseExecutorFactory.ts
@@ -1,4 +1,4 @@
-import { UseCaseExecutor } from "./UseCaseExecutor";
+import { UseCaseExecutorImpl } from "./UseCaseExecutor";
 import { UseCaseFunction } from "./FunctionalUseCaseContext";
 import { FunctionalUseCase } from "./FunctionalUseCase";
 import { UseCaseLike } from "./UseCaseLike";
@@ -9,12 +9,15 @@ import { Dispatcher } from "./Dispatcher";
 export function createUseCaseExecutor(
     useCase: UseCaseFunction,
     dispatcher: Dispatcher
-): UseCaseExecutor<FunctionalUseCase>;
-export function createUseCaseExecutor<T extends UseCaseLike>(useCase: T, dispatcher: Dispatcher): UseCaseExecutor<T>;
-export function createUseCaseExecutor(useCase: any, dispatcher: Dispatcher): UseCaseExecutor<any> {
+): UseCaseExecutorImpl<FunctionalUseCase>;
+export function createUseCaseExecutor<T extends UseCaseLike>(
+    useCase: T,
+    dispatcher: Dispatcher
+): UseCaseExecutorImpl<T>;
+export function createUseCaseExecutor(useCase: any, dispatcher: Dispatcher): UseCaseExecutorImpl<any> {
     // instance of UseCase
     if (isUseCase(useCase)) {
-        return new UseCaseExecutor({
+        return new UseCaseExecutorImpl({
             useCase,
             parent: isUseCase(dispatcher) ? dispatcher : null,
             dispatcher
@@ -28,7 +31,7 @@ The argument is UseCase constructor itself: ${useCase}`
         );
         // function to be FunctionalUseCase
         const functionalUseCase = new FunctionalUseCase(useCase);
-        return new UseCaseExecutor({
+        return new UseCaseExecutorImpl({
             useCase: functionalUseCase,
             parent: isUseCase(dispatcher) ? dispatcher : null,
             dispatcher

--- a/packages/almin/src/index.ts
+++ b/packages/almin/src/index.ts
@@ -4,7 +4,6 @@ export { Dispatcher } from "./Dispatcher";
 export { Store } from "./Store";
 export { StoreGroup } from "./UILayer/StoreGroup";
 export { UseCase } from "./UseCase";
-export { UseCaseExecutor } from "./UseCaseExecutor";
 export { Context } from "./Context";
 export { FunctionalUseCaseContext } from "./FunctionalUseCaseContext";
 // payload
@@ -20,6 +19,7 @@ export { DispatcherPayloadMeta } from "./DispatcherPayloadMeta";
 // For TypeScript
 import * as StoreGroupTypes from "./UILayer/StoreGroupTypes";
 export { StoreGroupTypes };
+export { UseCaseExecutor } from "./UseCaseExecutor";
 export { StoreLike } from "./StoreLike";
 export { UseCaseLike } from "./UseCaseLike";
 export { DispatchedPayload } from "./Dispatcher";

--- a/packages/almin/test/Context-test.js
+++ b/packages/almin/test/Context-test.js
@@ -7,7 +7,7 @@ import { CompletedPayload, DidExecutedPayload, WillExecutedPayload } from "../sr
 import { Store } from "../src/Store";
 import { StoreGroup } from "../src/UILayer/StoreGroup";
 import { UseCase } from "../src/UseCase";
-import { UseCaseExecutor } from "../src/UseCaseExecutor";
+import { UseCaseExecutorImpl } from "../src/UseCaseExecutor";
 import { createStore } from "./helper/create-new-store";
 import { createEchoStore } from "./helper/EchoStore";
 import { DispatchUseCase } from "./use-case/DispatchUseCase";
@@ -302,7 +302,7 @@ describe("Context", function() {
                 store: createEchoStore({ echo: { "1": 1 } })
             });
             const useCaseExecutor = appContext.useCase(new ThrowUseCase());
-            assert.ok(useCaseExecutor instanceof UseCaseExecutor);
+            assert.ok(useCaseExecutor instanceof UseCaseExecutorImpl);
             useCaseExecutor.execute();
         });
         it("should release defaultUnitOfWork after UseCase#execute is completed", function() {

--- a/packages/almin/test/UseCaseExecutor-test.js
+++ b/packages/almin/test/UseCaseExecutor-test.js
@@ -5,7 +5,7 @@ const assert = require("assert");
 import { SyncNoDispatchUseCase } from "./use-case/SyncNoDispatchUseCase";
 import { Dispatcher } from "../src/Dispatcher";
 import { UseCase } from "../src/UseCase";
-import { UseCaseExecutor } from "../src/UseCaseExecutor";
+import { UseCaseExecutorImpl } from "../src/UseCaseExecutor";
 import { CallableUseCase } from "./use-case/CallableUseCase";
 import { ThrowUseCase } from "./use-case/ThrowUseCase";
 import { isWillExecutedPayload } from "../src/payload/WillExecutedPayload";
@@ -23,7 +23,7 @@ describe("UseCaseExecutor", function() {
         });
         it("should catch sync throwing error in UseCase", () => {
             const dispatcher = new Dispatcher();
-            const executor = new UseCaseExecutor({
+            const executor = new UseCaseExecutorImpl({
                 useCase: new ThrowUseCase(),
                 dispatcher
             });
@@ -38,7 +38,7 @@ describe("UseCaseExecutor", function() {
         });
         it("should throw error when pass non-executor function and output console.error", () => {
             const dispatcher = new Dispatcher();
-            const executor = new UseCaseExecutor({
+            const executor = new UseCaseExecutorImpl({
                 useCase: new SyncNoDispatchUseCase(),
                 dispatcher
             });
@@ -60,7 +60,7 @@ describe("UseCaseExecutor", function() {
         it("should accept executor(useCase => {}) function arguments", () => {
             const dispatcher = new Dispatcher();
             const callableUseCase = new CallableUseCase();
-            const executor = new UseCaseExecutor({
+            const executor = new UseCaseExecutorImpl({
                 useCase: callableUseCase,
                 dispatcher
             });
@@ -81,7 +81,7 @@ describe("UseCaseExecutor", function() {
         });
         it("executor(useCase => {}) useCase is actual wrapper object", () => {
             const dispatcher = new Dispatcher();
-            const executor = new UseCaseExecutor({
+            const executor = new UseCaseExecutorImpl({
                 useCase: new SyncNoDispatchUseCase(),
                 dispatcher
             });
@@ -94,7 +94,7 @@ describe("UseCaseExecutor", function() {
         it("can call useCase.execute() by async", done => {
             const dispatcher = new Dispatcher();
             const callableUseCase = new CallableUseCase();
-            const executor = new UseCaseExecutor({
+            const executor = new UseCaseExecutorImpl({
                 useCase: callableUseCase,
                 dispatcher
             });
@@ -113,7 +113,7 @@ describe("UseCaseExecutor", function() {
         });
         it("should show warning when UseCase#execute twice", () => {
             const dispatcher = new Dispatcher();
-            const executor = new UseCaseExecutor({
+            const executor = new UseCaseExecutorImpl({
                 useCase: new SyncNoDispatchUseCase(),
                 dispatcher
             });
@@ -146,7 +146,7 @@ describe("UseCaseExecutor", function() {
 
             const callStack = [];
             const expectedCallStack = ["will", "dispatch", "did", "complete"];
-            const executor = new UseCaseExecutor({
+            const executor = new UseCaseExecutorImpl({
                 useCase: new SyncUseCase(),
                 dispatcher
             });
@@ -171,7 +171,7 @@ describe("UseCaseExecutor", function() {
     describe("#execute", function() {
         it("should catch sync throwing error in UseCase", () => {
             const dispatcher = new Dispatcher();
-            const executor = new UseCaseExecutor({
+            const executor = new UseCaseExecutorImpl({
                 useCase: new ThrowUseCase(),
                 dispatcher
             });
@@ -202,7 +202,7 @@ describe("UseCaseExecutor", function() {
                 }
 
                 // when
-                const executor = new UseCaseExecutor({
+                const executor = new UseCaseExecutorImpl({
                     useCase: new SyncUseCase(),
                     dispatcher
                 });
@@ -240,7 +240,7 @@ describe("UseCaseExecutor", function() {
                 let isCalledDidExecuted = false;
                 let isCalledCompleted = false;
                 // when
-                const executor = new UseCaseExecutor({
+                const executor = new UseCaseExecutorImpl({
                     useCase: new AsyncUseCase(),
                     dispatcher
                 });

--- a/tools/d.ts-markdown.jst
+++ b/tools/d.ts-markdown.jst
@@ -31,7 +31,7 @@ function renderAPIHeader(section) {
    // remove } block
    const header = stripIndent(section.codeText.replace(/}$/m, "")).trim();
    if(header.split("\n").length > 1){
-     return "### Interface of \n"
+     return "### Interface \n"
       + "```typescript\n"
       + header + "\n"
       + "```";

--- a/tools/update-api-reference.sh
+++ b/tools/update-api-reference.sh
@@ -16,6 +16,7 @@ npm run build
 cd "${projectDir}"
 # update
 addDoc "${srcDir}/Context.d.ts"
+addDoc "${srcDir}/UseCaseExecutor.d.ts"
 addDoc "${srcDir}/LifeCycleEventHub.d.ts"
 addDoc "${srcDir}/Dispatcher.d.ts"
 addDoc "${srcDir}/DispatcherPayloadMeta.d.ts"


### PR DESCRIPTION
Export `UseCaseExecutor` interface insteadof `UseCaseExecutorImpl`.
It is more safer for user.
I think that the user can't create new `UseCaseExecutor`.
So, we should not export `UseCaseExecutorImpl`