### PR TITLE
docs(tutorial): fix a typo

### DIFF
--- a/docs/tutorial/todomvc/README.md
+++ b/docs/tutorial/todomvc/README.md
@@ -140,7 +140,7 @@ export default class TodoList {
 }
 ```
 
-We can focus on bushiness logic because domain model is a just plain JavaScript.
+We can focus on business logic because domain model is a just plain JavaScript.
 
 ### Where domain model are stored?
 


### PR DESCRIPTION
`bushiness` -> `business`