### PR TITLE
test(almin): use deepEqual insteadof deepStrictEqual

### DIFF
--- a/docs/tips/performance-profile.md
+++ b/docs/tips/performance-profile.md
@@ -50,6 +50,15 @@ const appContext = new Context({
 });
 ```
 
+### Steps
+
+1. Turn on `performanceProfile` option
+2. Load your app
+3. Open the browser DevTools "Performance" tab and press **Record**
+    - For more details, See [Chrome's Timeline Tool document](https://developers.google.com/web/tools/chrome-devtools/evaluate-performance/timeline-tool) and [MSEdge's F12 devtools guide](https://docs.microsoft.com/en-us/microsoft-edge/f12-devtools-guide/performance "F12 devtools guide - Performance - Microsoft Edge Development | Microsoft Docs")
+4. Stop recording
+5. Almin events will be grouped under the **User Timing** label
+
 ## Related
 
 - [UseCase LifeCycle](./usecase-lifecycle.md)

--- a/docs/tips/performance-profile.md
+++ b/docs/tips/performance-profile.md
@@ -1,5 +1,7 @@
 # Performance profile
 
+> Almin 1.4.0+
+
 You can profiling UseCase execute, StoreGroup write/read, Store update using the browser developer tool timeline.
 
 The example of profiling result.

--- a/docs/tips/performance-profile.md
+++ b/docs/tips/performance-profile.md
@@ -22,7 +22,7 @@ The example of profiling result.
 
 Related: [UseCase LifeCycle](./usecase-lifecycle.md)
 
-## How to enable?
+## How to use?
 
 You can turn on performance profile by `performanceProfile` option. 
 

--- a/packages/almin/test/AlminPerfMarker-test.ts
+++ b/packages/almin/test/AlminPerfMarker-test.ts
@@ -87,7 +87,7 @@ describe("AlminPerfMarker", () => {
                     });
             })
             .then(() => {
-                assert.deepStrictEqual(markedEvents, expected);
+                assert.deepEqual(markedEvents, expected);
             });
     });
 });


### PR DESCRIPTION
Browser env not support strict...

Fix failure browser test on SauceLabs