### PR TITLE
chore(almin): Deprecate ChangedPayload

### DIFF
--- a/packages/almin/src/payload/ChangedPayload.ts
+++ b/packages/almin/src/payload/ChangedPayload.ts
@@ -10,9 +10,11 @@ export const TYPE = "ALMIN__ChangedPayload__";
 /**
  * ChangePayload is that represent something is changed.
  * Often, Store is changed.
+ * @deprecated
  */
 export class ChangedPayload extends Payload {
     constructor() {
         super({ type: TYPE });
+        console.warn("ChangedPayload will be removed.");
     }
 }


### PR DESCRIPTION
almin@0.14.0 deprecated `ChangedPayload`.

refs #281 