### PR TITLE
 fix(almin): Payload subclass need to define "type" property 

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "textlint-rule-common-misspellings": "^1.0.1",
     "textlint-rule-no-dead-link": "^3.0.1",
     "textlint-rule-prh": "^5.0.1",
-    "typescript": "^2.4.2"
+    "typescript": "~2.6.1"
   },
   "scripts": {
     "precommit": "lint-staged",

--- a/packages/almin/package.json
+++ b/packages/almin/package.json
@@ -72,7 +72,7 @@
     "sinon": "^2.3.8",
     "size-limit": "^0.11.4",
     "source-map-support": "^0.4.15",
-    "typescript": "~2.3.1",
+    "typescript": "~2.6.1",
     "zuul": "^3.10.1"
   },
   "dependencies": {

--- a/packages/almin/src/Context.ts
+++ b/packages/almin/src/Context.ts
@@ -14,7 +14,6 @@ import { WillExecutedPayload } from "./payload/WillExecutedPayload";
 import { UseCaseFunction } from "./FunctionalUseCaseContext";
 import { FunctionalUseCase } from "./FunctionalUseCase";
 import { StateMap } from "./UILayer/StoreGroupTypes";
-import { UseCaseLike } from "./UseCaseLike";
 import { UseCaseUnitOfWork } from "./UnitOfWork/UseCaseUnitOfWork";
 import { StoreGroup } from "./UILayer/StoreGroup";
 import { createUseCaseExecutor } from "./UseCaseExecutorFactory";
@@ -25,6 +24,7 @@ import { LifeCycleEventHub } from "./LifeCycleEventHub";
 import { StoreChangedPayload } from "./payload/StoreChangedPayload";
 import AlminInstruments from "./instrument/AlminInstruments";
 import { ContextConfig } from "./ContextConfig";
+import { UseCase } from "./UseCase";
 
 const deprecateWarning = (methodName: string) => {
     console.warn(`Deprecated: Context.prototype.${methodName} is deprecated.
@@ -147,8 +147,7 @@ export class Context<T> {
 
         // life-cycle event hub
         this.lifeCycleEventHub = new LifeCycleEventHub({
-            dispatcher: this.dispatcher,
-            storeGroup: this.storeGroup
+            dispatcher: this.dispatcher
         });
 
         const options = args.options || {};
@@ -288,8 +287,8 @@ export class Context<T> {
      * context.useCase(awesomeUseCase).execute([1, 2, 3]);
      * ```
      */
+    useCase<T extends UseCase>(useCase: T): UseCaseExecutor<T>;
     useCase(useCase: UseCaseFunction): UseCaseExecutor<FunctionalUseCase>;
-    useCase<T extends UseCaseLike>(useCase: T): UseCaseExecutor<T>;
     useCase(useCase: any): UseCaseExecutor<any> {
         const useCaseExecutor = createUseCaseExecutor(useCase, this.dispatcher);
         const unitOfWork = new UseCaseUnitOfWork({
@@ -424,7 +423,7 @@ Please enable strict mode via \`new Context({ dispatcher, store, options: { stri
             storeGroup: this.storeGroup,
             options: { autoCommit: false }
         });
-        const createUseCaseExecutorAndOpenUoW = <T extends UseCaseLike>(useCase: T): UseCaseExecutor<T> => {
+        const createUseCaseExecutorAndOpenUoW = <T extends UseCase>(useCase: T): UseCaseExecutor<T> => {
             const useCaseExecutor = createUseCaseExecutor(useCase, this.dispatcher);
             unitOfWork.open(useCaseExecutor);
             return useCaseExecutor;

--- a/packages/almin/src/FunctionalUseCaseContext.ts
+++ b/packages/almin/src/FunctionalUseCaseContext.ts
@@ -11,7 +11,14 @@ import { Payload } from "./payload/Payload";
  * }
  * ```
  */
-export type UseCaseFunction = (context?: FunctionalUseCaseContext) => (...args: Array<any>) => any;
+export type UseCaseFunction = (context: FunctionalUseCaseContext) => (...args: Array<any>) => any;
+
+/**
+ * Is `v` is UseCaseFunction?
+ */
+export const isUseCaseFunction = (v: any): v is UseCaseFunction => {
+    return typeof v === "function";
+};
 
 /**
  * Send only dispatcher

--- a/packages/almin/src/LifeCycleEventHub.ts
+++ b/packages/almin/src/LifeCycleEventHub.ts
@@ -5,14 +5,12 @@ import { DispatcherPayloadMeta } from "./DispatcherPayloadMeta";
 import { DidExecutedPayload, isDidExecutedPayload } from "./payload/DidExecutedPayload";
 import { CompletedPayload, isCompletedPayload } from "./payload/CompletedPayload";
 import { ErrorPayload, isErrorPayload } from "./payload/ErrorPayload";
-import { StoreGroupLike } from "./UILayer/StoreGroupLike";
-import { TransactionBeganPayload, isTransactionBeganPayload } from "./payload/TransactionBeganPayload";
-import { TransactionEndedPayload, isTransactionEndedPayload } from "./payload/TransactionEndedPayload";
+import { isTransactionBeganPayload, TransactionBeganPayload } from "./payload/TransactionBeganPayload";
+import { isTransactionEndedPayload, TransactionEndedPayload } from "./payload/TransactionEndedPayload";
 import { isStoreChangedPayload, StoreChangedPayload } from "./payload/StoreChangedPayload";
 
 export interface LifeCycleEventHubArgs {
     dispatcher: Dispatcher;
-    storeGroup: StoreGroupLike;
 }
 
 /**
@@ -29,11 +27,9 @@ export class LifeCycleEventHub {
      */
     private releaseHandlers: (() => void)[];
     private dispatcher: Dispatcher;
-    private storeGroup: StoreGroupLike;
 
     constructor(args: LifeCycleEventHubArgs) {
         this.dispatcher = args.dispatcher;
-        this.storeGroup = args.storeGroup;
         this.releaseHandlers = [];
     }
 

--- a/packages/almin/src/UILayer/SingleStoreGroup.ts
+++ b/packages/almin/src/UILayer/SingleStoreGroup.ts
@@ -13,14 +13,11 @@ import { StoreLike } from "../StoreLike";
  */
 export class SingleStoreGroup<T extends Store> extends Dispatcher implements StoreGroupLike {
     private storeGroup: StoreGroup<{ target: T }>;
-    private store: T;
-
-    name: string;
+    readonly name: string;
 
     constructor(store: T) {
         super();
         this.name = `SingleStoreGroup(${store.name})`;
-        this.store = store;
         this.storeGroup = new StoreGroup({
             target: store
         });

--- a/packages/almin/src/UILayer/StoreStateMap.ts
+++ b/packages/almin/src/UILayer/StoreStateMap.ts
@@ -2,6 +2,7 @@
 import { MapLike } from "map-like";
 import { Store } from "../Store";
 import { StoreMap } from "./StoreGroupTypes";
+
 /**
  * TODO: make strong type
  */
@@ -31,7 +32,8 @@ export class StoreStateMap extends MapLike<Store, string> {
  */
 export function createStoreStateMap<T>(mappingObject: StoreMap<T>): StoreStateMap {
     const map = new StoreStateMap();
-    const keys = Object.keys(mappingObject);
+    // Suppress: Element implicitly has an 'any' type because type 'StoreMap<T>' has no index signature.
+    const keys = Object.keys(mappingObject) as (keyof T)[];
     for (let i = 0; i < keys.length; i++) {
         const stateName = keys[i];
         const store = mappingObject[stateName];

--- a/packages/almin/src/UseCaseExecutorFactory.ts
+++ b/packages/almin/src/UseCaseExecutorFactory.ts
@@ -1,7 +1,6 @@
 import { UseCaseExecutorImpl } from "./UseCaseExecutor";
-import { UseCaseFunction } from "./FunctionalUseCaseContext";
+import { isUseCaseFunction, UseCaseFunction } from "./FunctionalUseCaseContext";
 import { FunctionalUseCase } from "./FunctionalUseCase";
-import { UseCaseLike } from "./UseCaseLike";
 import { isUseCase, UseCase } from "./UseCase";
 import * as assert from "assert";
 import { Dispatcher } from "./Dispatcher";
@@ -10,10 +9,7 @@ export function createUseCaseExecutor(
     useCase: UseCaseFunction,
     dispatcher: Dispatcher
 ): UseCaseExecutorImpl<FunctionalUseCase>;
-export function createUseCaseExecutor<T extends UseCaseLike>(
-    useCase: T,
-    dispatcher: Dispatcher
-): UseCaseExecutorImpl<T>;
+export function createUseCaseExecutor<T extends UseCase>(useCase: T, dispatcher: Dispatcher): UseCaseExecutorImpl<T>;
 export function createUseCaseExecutor(useCase: any, dispatcher: Dispatcher): UseCaseExecutorImpl<any> {
     // instance of UseCase
     if (isUseCase(useCase)) {
@@ -22,7 +18,7 @@ export function createUseCaseExecutor(useCase: any, dispatcher: Dispatcher): Use
             parent: isUseCase(dispatcher) ? dispatcher : null,
             dispatcher
         });
-    } else if (typeof useCase === "function") {
+    } else if (isUseCaseFunction(useCase)) {
         // When pass UseCase constructor itself, throw assertion error
         assert.ok(
             Object.getPrototypeOf && Object.getPrototypeOf(useCase) !== UseCase,

--- a/packages/almin/src/payload/ChangedPayload.ts
+++ b/packages/almin/src/payload/ChangedPayload.ts
@@ -13,6 +13,7 @@ export const TYPE = "ALMIN__ChangedPayload__";
  * @deprecated
  */
 export class ChangedPayload extends Payload {
+    type: typeof TYPE;
     constructor() {
         super({ type: TYPE });
         console.warn("ChangedPayload will be removed.");

--- a/packages/almin/src/payload/CompletedPayload.ts
+++ b/packages/almin/src/payload/CompletedPayload.ts
@@ -9,6 +9,7 @@ import { Payload } from "./Payload";
 export const TYPE = "ALMIN__COMPLETED_EACH_USECASE__";
 
 export class CompletedPayload extends Payload {
+    type: typeof TYPE;
     /**
      * the value is returned by the useCase
      * Difference of DidExecutedPayload, the value always is resolved value.

--- a/packages/almin/src/payload/DidExecutedPayload.ts
+++ b/packages/almin/src/payload/DidExecutedPayload.ts
@@ -9,6 +9,7 @@ import { Payload } from "./Payload";
 export const TYPE = "ALMIN__DID_EXECUTED_EACH_USECASE__";
 
 export class DidExecutedPayload extends Payload {
+    type: typeof TYPE;
     /**
      * the value is returned by the useCase
      * Maybe Promise or some value or undefined.

--- a/packages/almin/src/payload/ErrorPayload.ts
+++ b/packages/almin/src/payload/ErrorPayload.ts
@@ -12,6 +12,7 @@ export const TYPE = "ALMIN__ErrorPayload__";
  * This payload is executed
  */
 export class ErrorPayload extends Payload {
+    type: typeof TYPE;
     /**
      * the `error` in the UseCase
      */

--- a/packages/almin/src/payload/InitializedPayload.ts
+++ b/packages/almin/src/payload/InitializedPayload.ts
@@ -13,6 +13,7 @@ export const TYPE = "Almin__InitializedPayload__";
  * DO NOT USE THIS in your application.
  */
 export class InitializedPayload extends Payload {
+    type: typeof TYPE;
     constructor() {
         super({ type: TYPE });
     }

--- a/packages/almin/src/payload/Payload.ts
+++ b/packages/almin/src/payload/Payload.ts
@@ -11,7 +11,7 @@ export abstract class Payload {
      * A `type` property which may not be `undefined`
      * It is a good idea to use string constants or Symbol for payload types.
      */
-    readonly type: any;
+    abstract readonly type: any;
 
     constructor(args?: PayloadArgs) {
         if (args) {

--- a/packages/almin/src/payload/StoreChangedPayload.ts
+++ b/packages/almin/src/payload/StoreChangedPayload.ts
@@ -12,6 +12,7 @@ export const TYPE = "ALMIN_STORE_IS_CHANGED__";
  * ChangePayload is that represent a store is changed.
  */
 export class StoreChangedPayload extends Payload {
+    type: typeof TYPE;
     store: StoreLike<any>;
 
     constructor(store: StoreLike<any>) {

--- a/packages/almin/src/payload/TransactionBeganPayload.ts
+++ b/packages/almin/src/payload/TransactionBeganPayload.ts
@@ -11,6 +11,7 @@ export const TYPE = "ALMIN_BEGAN_OF_TRANSACTION__";
  * TransactionBeganPayload is begin of transaction
  */
 export class TransactionBeganPayload extends Payload {
+    type: typeof TYPE;
     // transaction name
     name: string;
 

--- a/packages/almin/src/payload/TransactionEndedPayload.ts
+++ b/packages/almin/src/payload/TransactionEndedPayload.ts
@@ -11,6 +11,7 @@ export const TYPE = "ALMIN_ENF_OF_TRANSACTION__";
  * TransactionEndedPayload is end of transaction
  */
 export class TransactionEndedPayload extends Payload {
+    type: typeof TYPE;
     // transaction name
     name: string;
 

--- a/packages/almin/src/payload/WillExecutedPayload.ts
+++ b/packages/almin/src/payload/WillExecutedPayload.ts
@@ -9,6 +9,7 @@ import { Payload } from "./Payload";
 export const TYPE = "ALMIN__WILL_EXECUTED_EACH_USECASE__";
 
 export class WillExecutedPayload extends Payload {
+    type: typeof TYPE;
     /**
      * a array for argument of the useCase
      */

--- a/packages/almin/test/Dispatcher-test.ts
+++ b/packages/almin/test/Dispatcher-test.ts
@@ -30,7 +30,7 @@ describe("Dispatcher", function() {
         it("when dispatch Payload instance that have not type, should throw error", function() {
             const dispatcher = new Dispatcher();
 
-            // @ts-ignore
+            // @ts-ignore: missing type
             class MyPayload extends Payload {}
 
             try {

--- a/packages/almin/test/Dispatcher-test.ts
+++ b/packages/almin/test/Dispatcher-test.ts
@@ -1,7 +1,7 @@
 // LICENSE : MIT
 "use strict";
 const assert = require("assert");
-import { Dispatcher } from "../src/";
+import { Dispatcher, Payload } from "../src/";
 
 describe("Dispatcher", function() {
     describe("#onDispatch", function() {
@@ -26,6 +26,37 @@ describe("Dispatcher", function() {
             } catch (error) {
                 assert(error.message !== "UNREACHED");
             }
+        });
+        it("when dispatch Payload instance that have not type, should throw error", function() {
+            const dispatcher = new Dispatcher();
+
+            // @ts-ignore
+            class MyPayload extends Payload {}
+
+            try {
+                dispatcher.dispatch(new MyPayload());
+                throw new Error("UNREACHED");
+            } catch (error) {
+                assert(error.message !== "UNREACHED");
+            }
+        });
+        it("when dispatch Payload instance, should pass test", function(done) {
+            const dispatcher = new Dispatcher();
+
+            class MyPayload extends Payload {
+                type: string;
+
+                // Not have type
+                constructor() {
+                    super({ type: "MyPayload" });
+                }
+            }
+
+            dispatcher.onDispatch(payload => {
+                assert.ok(payload instanceof MyPayload);
+                done();
+            });
+            dispatcher.dispatch(new MyPayload());
         });
         it("when dispatch with payload that has string type, should pass test", function(done) {
             const dispatcher = new Dispatcher();

--- a/packages/almin/test/Dispatcher-test.ts
+++ b/packages/almin/test/Dispatcher-test.ts
@@ -1,8 +1,7 @@
 // LICENSE : MIT
 "use strict";
 const assert = require("assert");
-
-import { Dispatcher } from "../src/Dispatcher";
+import { Dispatcher } from "../src/";
 
 describe("Dispatcher", function() {
     describe("#onDispatch", function() {
@@ -19,16 +18,27 @@ describe("Dispatcher", function() {
         });
     });
     describe("#dispatch", function() {
-        it("should dispatch with payload object, otherwise throw error", function() {
+        it("when dispatch string, should throw error", function() {
             const dispatcher = new Dispatcher();
             try {
-                dispatcher.dispatch("it is not payload");
+                dispatcher.dispatch("it is not payload" as any);
                 throw new Error("UNREACHED");
             } catch (error) {
                 assert(error.message !== "UNREACHED");
             }
         });
-        it("should dispatch with payload object that has type propery", function(done) {
+        it("when dispatch with payload that has string type, should pass test", function(done) {
+            const dispatcher = new Dispatcher();
+            const expectedPayload = {
+                type: "string type"
+            };
+            dispatcher.onDispatch(payload => {
+                assert.deepEqual(payload, expectedPayload);
+                done();
+            });
+            dispatcher.dispatch(expectedPayload);
+        });
+        it("when dispatch with payload that has object type, should pass test", function(done) {
             const dispatcher = new Dispatcher();
             const expectedPayload = {
                 type: {
@@ -41,7 +51,20 @@ describe("Dispatcher", function() {
             });
             dispatcher.dispatch(expectedPayload);
         });
-        it("should pass payload object to listening handler", function(done) {
+        it("when dispatch with payload object that has type property, should pass test", function(done) {
+            const dispatcher = new Dispatcher();
+            const expectedPayload = {
+                type: {
+                    /* string Symbol anything */
+                }
+            };
+            dispatcher.onDispatch(payload => {
+                assert.deepEqual(payload, expectedPayload);
+                done();
+            });
+            dispatcher.dispatch(expectedPayload);
+        });
+        it("when dispatch payload object, listen handler catch the payload", function(done) {
             const dispatcher = new Dispatcher();
             const expectedPayload = {
                 type: "pay",

--- a/packages/almin/test/typescript/almin-loading.ts
+++ b/packages/almin/test/typescript/almin-loading.ts
@@ -1,17 +1,23 @@
 // Loading UseCase & Store Example
 import { Context, Store, Dispatcher, UseCase, Payload } from "../../src/index";
+
 // custom payload
 class LoadingPayload extends Payload {
+    type = "MyPayload";
+
     constructor(public isLoading: boolean) {
-        super({ type: "MyPayload" });
+        super();
     }
 }
+
 type UpdateLoadingUseCaseArg = boolean;
+
 class UpdateLoadingUseCase extends UseCase {
     execute(isLoading: UpdateLoadingUseCaseArg) {
         this.dispatch(new LoadingPayload(isLoading));
     }
 }
+
 class LoadingState {
     constructor(public isLoading: boolean) {}
 
@@ -19,6 +25,7 @@ class LoadingState {
         return new LoadingState(isLoading);
     }
 }
+
 class LoadingStore extends Store<LoadingState> {
     state: LoadingState;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5270,9 +5270,9 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@^2.4.2:
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.4.2.tgz#f8395f85d459276067c988aa41837a8f82870844"
+typescript@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.6.1.tgz#ef39cdea27abac0b500242d6726ab90e0c846631"
 
 uglify-js@^2.6:
   version "2.8.22"


### PR DESCRIPTION
BREAKING CHANGE: It have a breaking change in TypeScript.

## Before

```js
// OK
class P1 extends Payload{
    type = "P1"
}
// OK
class P2 extends Payload {
    type: string;
    constructor() {
        super({ type: "P2" });
    }
}
// OK
class P3 extends Payload{
    constructor() {
        super({ type: "P2" });
    }
}
// OK - It is a bug
class P4 extends Payload{
    // no type
}
```

## After

If you have inherited `Payload` class, should have defined `type` property.

```js
// OK
class P1 extends Payload{
    type = "P1"
}
// OK
class P2 extends Payload {
    type: string;
    constructor() {
        super({ type: "P2" });
    }
}
// NG - Need to defined `type: string`
class P3 extends Payload{
    constructor() {
        super({ type: "P2" });
    }
}
// NG: Fix a bug #295 
class P4 extends Payload{
    // no type
}
```

fix #295 