### PR TITLE
docs(UseCase) Change the order of Functional UseCase examples

### DIFF
--- a/docs/Components.md
+++ b/docs/Components.md
@@ -82,21 +82,21 @@ useCase.execute();
 It is functional version of UseCase.
 
 ```js
-class AwesomeUseCase extends UseCase {
-   execute(...args){ }
-}
-
-context.useCase(new AwesomeUseCase()).execute([1, 2, 3]);
-```
-
-==
-
-```js
 const awesomeUseCase = ({dispatcher}) => {
    return (...args) => { }
 };
 
 context.useCase(awesomeUseCase).execute([1, 2, 3]);
+```
+
+==
+
+```js
+class AwesomeUseCase extends UseCase {
+   execute(...args){ }
+}
+
+context.useCase(new AwesomeUseCase()).execute([1, 2, 3]);
 ```
 
 The functional use-case is useful when the use-case do only `dispatch` like following.


### PR DESCRIPTION
I suppose it's clearer to show an example of Functional UseCase first.
Because the last sentence is 

> It is functional version of UseCase.`

so readers would expect to see a Functional UseCase example at the following line.

Thanks!