### PR TITLE
fix(React): Use componentDidMount instead of componentWillMount

### DIFF
--- a/docs/TutorialCounter.md
+++ b/docs/TutorialCounter.md
@@ -355,10 +355,13 @@ import { CounterState } from "../store/CounterState";
 import { Counter } from "./Counter";
 
 export default class App extends React.Component {
-    componentWillMount() {
-        const appContext = this.props.appContext;
+    constructor(props) {
+        super(props);
         // set initial state
-        this.setState(appContext.getState());
+        this.state = props.appContext.getState();
+    }
+    componentDidMount() {
+        const appContext = this.props.appContext;
         // update component's state with store's state when store is changed
         const onChangeHandler = () => {
             this.setState(appContext.getState());

--- a/examples/counter/src/component/App.js
+++ b/examples/counter/src/component/App.js
@@ -6,10 +6,13 @@ import { CounterState } from "../store/CounterState";
 import { Counter } from "./Counter";
 
 export default class App extends React.Component {
-    componentWillMount() {
-        const appContext = this.props.appContext;
+    constructor(props) {
+        super(props);
         // set initial state
-        this.setState(appContext.getState());
+        this.state = props.appContext.getState();
+    }
+    componentDidMount() {
+        const appContext = this.props.appContext;
         // update component's state with store's state when store is changed
         const onChangeHandler = () => {
             this.setState(appContext.getState());

--- a/packages/almin-react-container/src/almin-react-container.tsx
+++ b/packages/almin-react-container/src/almin-react-container.tsx
@@ -46,7 +46,7 @@ export class AlminReactContainer {
                 return !shallowEqual(this.state, nextState);
             }
 
-            componentWillMount() {
+            componentDidMount() {
                 const onChangeHandler = () => {
                     this.setState(context.getState());
                 };


### PR DESCRIPTION
React is going to deprecate `componentWillMount` so Almin should use `componentDidMount` instead of `componentWillMount`.
This PR includes fixes for documentation and an example and a source of `almin-react-container`.

Should I separate this PR each one?