### PR TITLE
fix(almin): fix to call didExecute when UseCase throw error

### DIFF
--- a/packages/almin-logger/test/AsyncLogger-test.js
+++ b/packages/almin-logger/test/AsyncLogger-test.js
@@ -22,9 +22,6 @@ import NoDispatchUseCase from "./usecase/NoDispatchUseCase";
 import { NotExecuteUseCase } from "./usecase/NotExecuteUseCase";
 import WrapUseCase from "./usecase/WrapUseCase";
 
-const shouldNotCalled = () => {
-    throw new Error("This should not be called");
-};
 describe("AsyncLogger", function() {
     it("can start and stop", () => {
         const consoleMock = ConsoleMock.create();
@@ -312,19 +309,17 @@ describe("AsyncLogger", function() {
             actualLogGroup = logGroup;
         });
         // When
-        const unExpectedPromise = context
+        return context
             .useCase(useCase)
             .execute()
-            .then(shouldNotCalled, shouldNotCalled);
-        const expected = Promise.resolve().then(() => {
-            assert(consoleMock.groupCollapsed.called);
-            const expectOutput = `NotExecuteUseCase`;
-            const isContain = consoleMock.log.calls.some(call => {
-                return call.arg && call.arg.indexOf(expectOutput) !== -1;
+            .then(() => {
+                assert(consoleMock.groupCollapsed.called);
+                const expectOutput = `NotExecuteUseCase`;
+                const isContain = consoleMock.log.calls.some(call => {
+                    return call.arg && call.arg.indexOf(expectOutput) !== -1;
+                });
+                assert.ok(isContain, `${expectOutput} is not found.`);
             });
-            assert.ok(isContain, `${expectOutput} is not found.`);
-        });
-        return Promise.race([unExpectedPromise, expected]);
     });
     it("should log dispatch event", function() {
         const consoleMock = ConsoleMock.create();

--- a/packages/almin/src/UseCaseExecutor.ts
+++ b/packages/almin/src/UseCaseExecutor.ts
@@ -371,6 +371,7 @@ export class UseCaseExecutorImpl<T extends UseCaseLike> extends Dispatcher imple
         }
         // Notes: proxyfiedUseCase has not timeout
         // proxiedUseCase will resolve by UseCaseWrapper#execute
+        // For more details, see <UseCaseLifeCycle-test.ts>
         const proxyfiedUseCase = proxifyUseCase<T>(this.useCase, {
             onWillNotExecute: args => {
                 this.willNotExecuteUseCase(args);
@@ -416,7 +417,7 @@ export class UseCaseExecutorImpl<T extends UseCaseLike> extends Dispatcher imple
                     });
                 }
                 case "SuccessExecuteNoReturnValue":
-                    // just success execute
+                    // The UseCase#execute just success without return value
                     return resolve();
             }
         });

--- a/packages/almin/test/DispatcherPayloadMeta-test.js
+++ b/packages/almin/test/DispatcherPayloadMeta-test.js
@@ -6,7 +6,7 @@ import { CompletedPayload, Context, DidExecutedPayload } from "../src/";
 import { Dispatcher } from "../src/Dispatcher";
 import { createStore } from "./helper/create-new-store";
 import { DispatchUseCase } from "./use-case/DispatchUseCase";
-import { ErrorUseCase } from "./use-case/ErrorUseCase";
+import { AsyncErrorUseCase } from "./use-case/AsyncErrorUseCase";
 import { ParentUseCase } from "./use-case/NestingUseCase";
 import { SyncNoDispatchUseCase } from "./use-case/SyncNoDispatchUseCase";
 import { AsyncUseCase } from "./use-case/AsyncUseCase";
@@ -140,7 +140,7 @@ describe("DispatcherPayloadMeta", () => {
                 dispatcher,
                 store: createStore({ name: "test" })
             });
-            const useCase = new ErrorUseCase();
+            const useCase = new AsyncErrorUseCase();
             let actualMeta = null;
             context.events.onErrorDispatch((payload, meta) => {
                 actualMeta = meta;

--- a/packages/almin/test/UseCaseExecutor-test.ts
+++ b/packages/almin/test/UseCaseExecutor-test.ts
@@ -44,15 +44,20 @@ describe("UseCaseExecutor", function() {
                 dispatcher,
                 parent: null
             });
-            return executor.executor(" THIS IS WRONG " as any).catch(error => {
-                assert.ok(consoleErrorStub.called, "should be called console.error");
-                const warningMessage = consoleErrorStub.getCalls()[0].args[0];
-                assert.ok(/executor.*? arguments should be function/.test(error.message));
-                assert.equal(
-                    warningMessage,
-                    "Warning(UseCase): executor argument should be function. But this argument is not function: "
-                );
-            });
+            return executor.executor(" THIS IS WRONG " as any).then(
+                () => {
+                    throw new Error("SHOULD NOT CALLED");
+                },
+                error => {
+                    assert.ok(consoleErrorStub.called, "should be called console.error");
+                    const warningMessage = consoleErrorStub.getCalls()[0].args[0];
+                    assert.ok(/executor.*? arguments should be function/.test(error.message));
+                    assert.equal(
+                        warningMessage,
+                        "Warning(UseCase): executor argument should be function. But this argument is not function: "
+                    );
+                }
+            );
         });
         it("should accept executor(useCase => {}) function arguments", () => {
             const dispatcher = new Dispatcher();

--- a/packages/almin/test/UseCaseExecutor-test.ts
+++ b/packages/almin/test/UseCaseExecutor-test.ts
@@ -158,7 +158,7 @@ describe("UseCaseExecutor", function() {
             });
             // when
             return executor.execute().catch(() => {
-                assert.deepStrictEqual(callStack, expectedCallStack);
+                assert.deepEqual(callStack, expectedCallStack);
             });
         });
     });

--- a/packages/almin/test/UseCaseLifeCycle-test.ts
+++ b/packages/almin/test/UseCaseLifeCycle-test.ts
@@ -1,0 +1,122 @@
+/*
+LifeCycle method order of call.
+
+| UseCase Type         | Will | Did  | Error | Complete | Return Promise                      |
+| -------------------- | ---- | ---- | ----- | -------- | ----------------------------------- |
+| Sync Success         | 1    | 2    | --    | 3        | resolve(then)                       |
+| Async Success        | 1    | 2    | --    | 3        | resolve(then)                       |
+| Sync Failure         | 1    | 3    | 2     | 4        | reject(catch)                       |
+| Async Failure        | 1    | 2    | 3     | 4        | reject(catch)                       |
+| ShouldExecute: false | --   | --   | --    | --       | resolve(then) - prevent memory leak |
+
+ */
+import * as assert from "assert";
+import { Context, Dispatcher } from "../src";
+import { createStore } from "./helper/create-new-store";
+import { NotExecuteUseCase } from "./use-case/NotExecuteUseCase";
+import { SyncNoDispatchUseCase } from "./use-case/SyncNoDispatchUseCase";
+import { AsyncUseCase } from "./use-case/AsyncUseCase";
+import { AsyncErrorUseCase } from "./use-case/AsyncErrorUseCase";
+import { ThrowUseCase } from "./use-case/ThrowUseCase";
+
+enum EventType {
+    WillNot = "WillNot",
+    Will = "Will",
+    Did = "Did",
+    Error = "Error",
+    Complete = "Complete"
+}
+
+const shouldNotCalled = () => {
+    throw new Error("This should not be called");
+};
+const createLogger = (context: Context<any>) => {
+    const eventLog: EventType[] = [];
+    context.events.onWillNotExecuteEachUseCase(() => {
+        eventLog.push(EventType.WillNot);
+    });
+    context.events.onWillExecuteEachUseCase(() => {
+        eventLog.push(EventType.Will);
+    });
+    context.events.onDidExecuteEachUseCase(() => {
+        eventLog.push(EventType.Did);
+    });
+    context.events.onErrorDispatch(() => {
+        eventLog.push(EventType.Error);
+    });
+    context.events.onCompleteEachUseCase(() => {
+        eventLog.push(EventType.Complete);
+    });
+    return {
+        getLog() {
+            return eventLog;
+        }
+    };
+};
+describe("UseCaseLifeCycle", () => {
+    it("Sync Success", () => {
+        const context = new Context({
+            dispatcher: new Dispatcher(),
+            store: createStore({ name: "test" })
+        });
+        const logger = createLogger(context);
+        return context
+            .useCase(new SyncNoDispatchUseCase())
+            .execute()
+            .then(() => {
+                assert.deepEqual(logger.getLog(), [EventType.Will, EventType.Did, EventType.Complete]);
+            }, shouldNotCalled);
+    });
+    it("ASync Success", () => {
+        const context = new Context({
+            dispatcher: new Dispatcher(),
+            store: createStore({ name: "test" })
+        });
+        const logger = createLogger(context);
+        return context
+            .useCase(new AsyncUseCase())
+            .execute()
+            .then(() => {
+                assert.deepEqual(logger.getLog(), [EventType.Will, EventType.Did, EventType.Complete]);
+            }, shouldNotCalled);
+    });
+    it("Sync Failure", () => {
+        const context = new Context({
+            dispatcher: new Dispatcher(),
+            store: createStore({ name: "test" })
+        });
+        const logger = createLogger(context);
+        return context
+            .useCase(new ThrowUseCase())
+            .execute()
+            .then(shouldNotCalled, () => {
+                assert.deepEqual(logger.getLog(), [EventType.Will, EventType.Error, EventType.Did, EventType.Complete]);
+            });
+    });
+    it("ASync Failure", () => {
+        const context = new Context({
+            dispatcher: new Dispatcher(),
+            store: createStore({ name: "test" })
+        });
+        const logger = createLogger(context);
+        return context
+            .useCase(new AsyncErrorUseCase())
+            .execute()
+            .then(shouldNotCalled, () => {
+                assert.deepEqual(logger.getLog(), [EventType.Will, EventType.Did, EventType.Error, EventType.Complete]);
+            });
+    });
+    it("ShouldExecute() => false", () => {
+        const context = new Context({
+            dispatcher: new Dispatcher(),
+            store: createStore({ name: "test" })
+        });
+        const logger = createLogger(context);
+        return context
+            .useCase(new NotExecuteUseCase())
+            .execute()
+            .then(() => {
+                assert.deepEqual(logger.getLog(), [EventType.WillNot]);
+            }, shouldNotCalled);
+    });
+});

--- a/packages/almin/test/mocha.opts
+++ b/packages/almin/test/mocha.opts
@@ -1,4 +1,3 @@
 --recursive
 --require env-development
 --require ts-node-test-register
---require source-map-support/register

--- a/packages/almin/test/use-case/AsyncErrorUseCase.ts
+++ b/packages/almin/test/use-case/AsyncErrorUseCase.ts
@@ -1,7 +1,7 @@
 // LICENSE : MIT
 "use strict";
 import { UseCase } from "../../src";
-export class ErrorUseCase extends UseCase {
+export class AsyncErrorUseCase extends UseCase {
     execute() {
         return Promise.reject(new Error("error"));
     }


### PR DESCRIPTION
This PR will fix "Failed to execute 'measure' on 'Performance'" error. #310

## Before

| UseCase Type         | Will | Did  | Error | Complete | Return Promise                      |
| -------------------- | ---- | ---- | ----- | -------- | ----------------------------------- |
| Sync Success         | 1    | 2    | --    | 3        | resolve(then)                       |
| Async Success        | 1    | 2    | --    | 3        | resolve(then)                       |
| Sync Failure         | 1    | --    | 2     | 3        | reject(catch)                       |
| Async Failure        | 1    | 2    | 3     | 4        | reject(catch)                       |
| ShouldExecute: false | --   | --   | --    | --       | resolve(then) - prevent memory leak |

**Sync Failure**  did not called `didExecute`.

## After

LifeCycle method order of call.

| UseCase Type         | Will | Did  | Error | Complete | Return Promise                      |
| -------------------- | ---- | ---- | ----- | -------- | ----------------------------------- |
| Sync Success         | 1    | 2    | --    | 3        | resolve(then)                       |
| Async Success        | 1    | 2    | --    | 3        | resolve(then)                       |
| Sync Failure         | 1    | 3    | 2     | 4        | reject(catch)                       |
| Async Failure        | 1    | 2    | 3     | 4        | reject(catch)                       |
| ShouldExecute: false | --   | --   | --    | --       | resolve(then) - prevent memory leak |

**Sync Failure**  have called `didExecute`.

- [x] We need to refactor the life cycle.

fix #310 