### PR TITLE
fix(almin): fix trouble emit `StoreChangedPayload`

### DIFF
--- a/packages/almin/src/Context.ts
+++ b/packages/almin/src/Context.ts
@@ -174,7 +174,10 @@ export class Context<T> {
                     useCase: undefined,
                     dispatcher: this.dispatcher,
                     parentUseCase: null,
-                    isTrusted: true, // <= StoreChangedPayload is always trusted
+                    // StoreChangedPayload is always trusted.
+                    // Because, StoreChangedPayload is created by almin, not user.
+                    // Related issue: https://github.com/almin/almin/issues/328
+                    isTrusted: true,
                     isUseCaseFinished: isUseCaseFinished,
                     transaction: transaction
                 });

--- a/packages/almin/src/Context.ts
+++ b/packages/almin/src/Context.ts
@@ -158,6 +158,7 @@ export class Context<T> {
         if (this.config.strict) {
             this.storeGroup.useStrict();
         }
+        // If some stores are changed, emit StoreChangedPayload
         // Store -> StoreGroup -> LifeCycleEventHub
         const storeGroupOnChangeToStoreChangedPayload = (
             stores: Array<StoreLike<any>>,
@@ -165,18 +166,18 @@ export class Context<T> {
         ) => {
             stores.forEach(store => {
                 const payload = new StoreChangedPayload(store);
-                // FIXME: store#emitChange -> isTruest:false event
                 // Should not included in StoreChanged Event
-                const meta = details
-                    ? details.meta
-                    : new DispatcherPayloadMetaImpl({
-                          useCase: undefined,
-                          dispatcher: this.dispatcher,
-                          parentUseCase: null,
-                          isTrusted: true,
-                          isUseCaseFinished: false,
-                          transaction: undefined
-                      });
+                // inherit some context from the reason of change details
+                const transaction = details && details.meta && details.meta.transaction;
+                const isUseCaseFinished = details && details.meta && details.meta.isUseCaseFinished;
+                const meta = new DispatcherPayloadMetaImpl({
+                    useCase: undefined,
+                    dispatcher: this.dispatcher,
+                    parentUseCase: null,
+                    isTrusted: true, // <= StoreChangedPayload is always trusted
+                    isUseCaseFinished: isUseCaseFinished,
+                    transaction: transaction
+                });
                 this.dispatcher.dispatch(payload, meta);
             });
         };

--- a/packages/almin/src/UILayer/StoreGroup.ts
+++ b/packages/almin/src/UILayer/StoreGroup.ts
@@ -466,18 +466,13 @@ But, ${store.name}#getState() was called.`
     /**
      * Observe changes of the store group.
      *
-     * `details` is the reason of changing stores.
-     * If `details` it not found, the reason by system.
-     *
-     * For example, the user can change store using `Store#emitChange` manually.
+     * For example, the user can change store using `Store#setState` manually.
      * In this case, the `details` is defined and report.
      *
-     * Contrast, almin try to update store in a lifecycle.
+     * Contrast, almin try to update store in a lifecycle(didUseCase, completeUseCase etc...).
      * In this case, the `details` is not defined and report.
      *
-     * TODO(azu): we should always define `details`
-     *
-     * onChange workflow: https://code2flow.com/mHFviS
+     * StoreGroup#onChange workflow: https://code2flow.com/mHFviS
      */
     onChange(handler: (stores: Array<Store<T>>, details?: StoreGroupReasonForChange) => void): () => void {
         this.on(CHANGE_STORE_GROUP, handler);

--- a/packages/almin/test/LifeCycleEventHub-test.ts
+++ b/packages/almin/test/LifeCycleEventHub-test.ts
@@ -1,0 +1,38 @@
+import * as assert from "assert";
+import { Context, DispatchedPayload, Dispatcher, DispatcherPayloadMeta, StoreGroup } from "../src";
+import { createUpdatableStoreWithUseCase } from "./helper/create-update-store-usecase";
+
+describe("LifeCycleEventHub", () => {
+    // https://github.com/almin/almin/issues/328
+    it("should sent `onDispatch` at once when dispatch and update store in UseCase", () => {
+        const { MockStore: AStore, MockUseCase: AUseCase } = createUpdatableStoreWithUseCase("A");
+        const aStore = new AStore();
+        const storeGroup = new StoreGroup({
+            a: aStore
+        });
+        const context = new Context({
+            dispatcher: new Dispatcher(),
+            store: storeGroup
+        });
+        const dispatchedLogs: [DispatchedPayload, DispatcherPayloadMeta][] = [];
+        context.events.onDispatch((payload, meta) => {
+            dispatchedLogs.push([payload, meta]);
+        });
+
+        // useCase
+        class ExampleUseCase extends AUseCase {
+            execute() {
+                this.dispatchUpdateState({
+                    value: "update value"
+                });
+            }
+        }
+
+        return context
+            .useCase(new ExampleUseCase())
+            .executor(useCase => useCase.execute())
+            .then(() => {
+                assert.equal(dispatchedLogs.length, 1, "should be dispatched at once");
+            });
+    });
+});

--- a/packages/almin/test/StoreGroup-edge-case-test.ts
+++ b/packages/almin/test/StoreGroup-edge-case-test.ts
@@ -1,7 +1,6 @@
 // LICENSE : MIT
 "use strict";
 const assert = require("assert");
-const sinon = require("sinon");
 import { Context, Dispatcher, Store, StoreGroup, UseCase } from "../src/";
 import { createUpdatableStoreWithUseCase } from "./helper/create-update-store-usecase";
 import { AsyncUseCase } from "./use-case/AsyncUseCase";
@@ -108,7 +107,7 @@ describe("StoreGroup edge case", function() {
                 store: storeGroup
             });
 
-            const callStack = [];
+            const callStack: string[] = [];
             context.onChange(() => {
                 callStack.push("change");
             });

--- a/packages/almin/test/helper/create-new-store.ts
+++ b/packages/almin/test/helper/create-new-store.ts
@@ -16,12 +16,14 @@ export interface MockStore {
 /**
  * This helper is for creating Store
  */
-export function createStore({ name, state }: { name: string; state?: any }) {
-    class MockStore extends Store implements MockStore {
+export function createStore<T>({ name, state }: { name: string; state?: T }) {
+    class MockStore extends Store<T | undefined> implements MockStore {
+        state: T | undefined;
+
         constructor() {
             super();
             this.name = name;
-            this.state = state || "value";
+            this.state = state;
         }
 
         /**


### PR DESCRIPTION
In some case, `LifeCycleEventHub#onDispatch` receive `StoreChangedPayload` #328
This fixes that `StoreChangedPayload` always be `isTrust: true` payload.
`LifeCycleEventHub#onDispatch` ignore trusted Payload.
As a result, LifeCycleEventHub#onDispatch have not received StoreChangedPayload.

fix #328

