### PR TITLE
feat(almin): Make `dispatcher` optional

### DIFF
--- a/docs/_ContextAPI.md
+++ b/docs/_ContextAPI.md
@@ -11,7 +11,7 @@ title: Context
 
 ```typescript
 export interface ContextArgs<T> {
-    dispatcher: Dispatcher;
+    dispatcher?: Dispatcher;
     store: StoreLike<T>;
     options?: {
         strict?: boolean;
@@ -57,17 +57,21 @@ const appContext = new Context({
 
 ----
 
-### `dispatcher: Dispatcher;`
+### `dispatcher?: Dispatcher;`
 
 
-Pass Dispatcher instance
+Dispatcher instance.
+
+Notes: Almin 0.16+
+
+It it optional parameter.
 
 ----
 
 ### `store: StoreLike<T>;`
 
 
-Pass StoreGroup instance
+StoreGroup instance
 
 ----
 
@@ -116,8 +120,7 @@ Context class provide observing and communicating with **Store** and **UseCase**
 ### `constructor(args: ContextArgs<T>);`
 
 
-`dispatcher` is an instance of `Dispatcher`.
-`store` is an instance of StoreLike implementation
+Context should be initialized with `store` that is an instance of StoreLike implementation
 
 ### Example
 
@@ -125,7 +128,6 @@ It is minimal initialization.
 
 ```js
 const context = new Context({
-  dispatcher: new Dispatcher(),
   store: new MyStore()
 });
 ```
@@ -137,7 +139,6 @@ const storeGroup = new StoreGroup([
   new AStore(), new BStore(), new CStore()
 ]);
 const context = new Context({
-  dispatcher: new Dispatcher(),
   store: storeGroup
 });
 ```

--- a/docs/_StoreGroupAPI.md
+++ b/docs/_StoreGroupAPI.md
@@ -77,7 +77,13 @@ shouldStateUpdate(prevState, nextState) {
 
 Observe changes of the store group.
 
-onChange workflow: https://code2flow.com/mHFviS
+For example, the user can change store using `Store#setState` manually.
+In this case, the `details` is defined and report.
+
+Contrast, almin try to update store in a lifecycle(didUseCase, completeUseCase etc...).
+In this case, the `details` is not defined and report.
+
+StoreGroup#onChange workflow: https://code2flow.com/mHFviS
 
 ----
 

--- a/packages/almin/src/Context.ts
+++ b/packages/almin/src/Context.ts
@@ -51,11 +51,15 @@ See https://github.com/almin/almin/releases/tag/almin%400.13.10 for more details
  */
 export interface ContextArgs<T> {
     /**
-     * Pass Dispatcher instance
+     * Dispatcher instance.
+     *
+     * Notes: Almin 0.16+
+     *
+     * It it optional parameter.
      */
-    dispatcher: Dispatcher;
+    dispatcher?: Dispatcher;
     /**
-     * Pass StoreGroup instance
+     * StoreGroup instance
      */
     store: StoreLike<T>;
     /**
@@ -100,8 +104,7 @@ export class Context<T> {
     private config: ContextConfig;
 
     /**
-     * `dispatcher` is an instance of `Dispatcher`.
-     * `store` is an instance of StoreLike implementation
+     * Context should be initialized with `store` that is an instance of StoreLike implementation
      *
      * ### Example
      *
@@ -109,7 +112,6 @@ export class Context<T> {
      *
      * ```js
      * const context = new Context({
-     *   dispatcher: new Dispatcher(),
      *   store: new MyStore()
      * });
      * ```
@@ -121,7 +123,6 @@ export class Context<T> {
      *   new AStore(), new BStore(), new CStore()
      * ]);
      * const context = new Context({
-     *   dispatcher: new Dispatcher(),
      *   store: storeGroup
      * });
      * ```
@@ -129,8 +130,10 @@ export class Context<T> {
     constructor(args: ContextArgs<T>) {
         const store = args.store;
         StoreGroupValidator.validateInstance(store);
-        // central dispatcher
-        this.dispatcher = args.dispatcher;
+        // Central dispatcher
+        // Almin 0.16+: dispatcher is optional.
+        // https://github.com/almin/almin/issues/185
+        this.dispatcher = args.dispatcher || new Dispatcher();
         // Implementation Note:
         // Delegate dispatch event to Store|StoreGroup from Dispatcher
         // StoreGroup call each Store#receivePayload, but pass directly Store is not.

--- a/packages/almin/test/Context-test.ts
+++ b/packages/almin/test/Context-test.ts
@@ -21,6 +21,7 @@ import { ParentUseCase } from "./use-case/NestingUseCase";
 import { NotExecuteUseCase } from "./use-case/NotExecuteUseCase";
 import { SinonStub } from "sinon";
 import { UseCaseFunction } from "../src/FunctionalUseCaseContext";
+import { createUpdatableStoreWithUseCase } from "./helper/create-update-store-usecase";
 
 const sinon = require("sinon");
 
@@ -543,6 +544,40 @@ describe("Context", function() {
                     assert.ok(callStack[index] instanceof ExpectedPayloadConstructor);
                 });
             });
+    });
+
+    describe("Dispatcher", () => {
+        it("`dispatcher` is optional", () => {
+            const { MockStore, MockUseCase } = createUpdatableStoreWithUseCase("test");
+
+            class UpdateUseCase extends MockUseCase {
+                execute() {
+                    this.dispatchUpdateState({
+                        value: "update"
+                    });
+                }
+            }
+
+            // Context class provide observing and communicating with **Store** and **UseCase**
+            const store = new MockStore();
+            const storeGroup = new StoreGroup({
+                test: store
+            });
+            const context = new Context({
+                dispatcher: new Dispatcher(),
+                store: storeGroup
+            });
+            return context
+                .useCase(new UpdateUseCase())
+                .execute()
+                .then(() => {
+                    assert.deepEqual(storeGroup.getState(), {
+                        test: {
+                            value: "update"
+                        }
+                    });
+                });
+        });
     });
 
     describe("Constructor with Store instance", () => {

--- a/packages/almin/test/helper/create-update-store-usecase.ts
+++ b/packages/almin/test/helper/create-update-store-usecase.ts
@@ -4,6 +4,7 @@ import { Payload, Store, UseCase } from "../../src";
 import { shallowEqual } from "shallow-equal-object";
 
 export function createUpdatableStoreWithUseCase(name: string) {
+    let isSharedStateChanged = false;
     let sharedState = {};
 
     /**
@@ -13,6 +14,7 @@ export function createUpdatableStoreWithUseCase(name: string) {
      */
     const requestUpdateState = (newState: any) => {
         sharedState = newState;
+        isSharedStateChanged = true;
     };
 
     class StoreUpdatePayload implements Payload {
@@ -53,8 +55,9 @@ export function createUpdatableStoreWithUseCase(name: string) {
         receivePayload(payload: Payload) {
             if (payload instanceof StoreUpdatePayload) {
                 this.setState(payload.state);
-            } else if (!shallowEqual(this.state, sharedState)) {
+            } else if (isSharedStateChanged && !shallowEqual(this.state, sharedState)) {
                 this.setState(sharedState);
+                isSharedStateChanged = false;
             }
         }
 


### PR DESCRIPTION
You can write follows in Almin 0.16+
```diff
const context = new Context({
-	dispatcher: new Dispatcher(),
	store: storeGroup
});
```

fix #185