### PR TITLE
fix(react-container): should be initialized before other component

### DIFF
--- a/packages/almin-react-container/src/almin-react-container.tsx
+++ b/packages/almin-react-container/src/almin-react-container.tsx
@@ -35,22 +35,20 @@ export class AlminReactContainer {
             state: P;
             unSubscribe: () => void | null;
 
+            onChangeHandler = () => {
+                this.setState(context.getState());
+            };
+
             constructor(props: any) {
                 super(props);
                 this.state = context.getState();
+                this.unSubscribe = context.onChange(this.onChangeHandler);
             }
 
             shouldComponentUpdate(_nextProps: any, nextState: any) {
                 // Almin StoreGroup use Object.assign merging by default
                 // It means that theses states are not strict equal always.
                 return !shallowEqual(this.state, nextState);
-            }
-
-            componentDidMount() {
-                const onChangeHandler = () => {
-                    this.setState(context.getState());
-                };
-                this.unSubscribe = context.onChange(onChangeHandler);
             }
 
             componentWillUnmount() {


### PR DESCRIPTION

We have used componentDidMount instead of componentWillMount in #321
But, Almin React Container should be initialized before other component.
Because, this component subscribe `Context#onChange`.
In other words, Almin React Container can not handle `Context#onchange` when some store has been changed in Other `Component#componentDidMount`.

Example:

```ts
const AppContainer = AlminReactContainer.create(App, context);
```

App:
```ts
export class App extends BaseContainer<typeof storeGroup.state> {
    componentDidMount() {
        // this usecase change the storegroup, but App does not re-render.
        this.useCase(new ConvertToAnnotationCollectionUseCase()).executor(useCase =>
            useCase.execute(fileAnnotationCollections)
        );
    }

    render() {

        return <div />
    }
}
```

This PR fix this issue.
`Context#onChaneg` should be executed in Constructor.
