### PR TITLE
refactor(almin): use Dispatcher insteadof events

### DIFF
--- a/packages/almin/src/Dispatcher.ts
+++ b/packages/almin/src/Dispatcher.ts
@@ -74,11 +74,11 @@ export type DispatchedPayload =
  * If apply emit style, we should cast `...args` for passing other dispatcher at every time.
  * So, Almin use `payload` object instead of it without casting.
  */
-export class Dispatcher extends EventEmitter {
+export class Dispatcher<Action extends AnyPayload = DispatchedPayload> extends EventEmitter {
     /**
      * if `v` is instance of Dispatcher, return true
      */
-    static isDispatcher(v: any): v is Dispatcher {
+    static isDispatcher(v: any): v is Dispatcher<any> {
         if (v instanceof Dispatcher) {
             return true;
         } else if (typeof v === "object" && typeof v.onDispatch === "function" && typeof v.dispatch === "function") {
@@ -108,7 +108,7 @@ export class Dispatcher extends EventEmitter {
      * unsubscribe(); // release handler
      * ```
      */
-    onDispatch(handler: (payload: DispatchedPayload, meta: DispatcherPayloadMeta) => void): () => void {
+    onDispatch(handler: (payload: Action, meta: DispatcherPayloadMeta) => void): () => void {
         this.on(ON_DISPATCH, handler);
         return this.removeListener.bind(this, ON_DISPATCH, handler);
     }
@@ -116,7 +116,7 @@ export class Dispatcher extends EventEmitter {
     /**
      * Dispatch `payload` to subscribers.
      */
-    dispatch(payload: DispatchedPayload, meta?: DispatcherPayloadMeta): void {
+    dispatch(payload: Action, meta?: DispatcherPayloadMeta): void {
         if (process.env.NODE_ENV !== "production") {
             assertOK(payload !== undefined && payload !== null, "payload should not null or undefined");
             assertOK(typeof payload.type !== "undefined", "payload's `type` should be required");
@@ -150,16 +150,16 @@ export class Dispatcher extends EventEmitter {
      * a.dispatch({ type : "a" });
      * ```
      */
-    pipe(toDispatcher: Dispatcher): () => void {
+    pipe(toDispatcher: Dispatcher<Action>): () => void {
         const fromName = this.constructor.name;
         const toName = toDispatcher.constructor.name;
         const displayName = `delegate-payload:${fromName}-to-${toName}`;
 
         type DelegatePayloadFn = {
-            (payload: DispatchedPayload, meta: DispatcherPayloadMeta): void;
+            (payload: Action, meta: DispatcherPayloadMeta): void;
             displayName: string;
         };
-        const delegatePayload = function delegatePayload(payload: DispatchedPayload, meta: DispatcherPayloadMeta) {
+        const delegatePayload = function delegatePayload(payload: Action, meta: DispatcherPayloadMeta) {
             (delegatePayload as DelegatePayloadFn).displayName = displayName;
             toDispatcher.dispatch(payload, meta);
         };

--- a/packages/almin/src/instrument/AlminPerfMarker.ts
+++ b/packages/almin/src/instrument/AlminPerfMarker.ts
@@ -4,7 +4,7 @@ import { StoreLike } from "../StoreLike";
 import { StoreGroupLike } from "../UILayer/StoreGroupLike";
 import { AlminPerfMarkerAbstract, DebugId, MarkType } from "./AlminAbstractPerfMarker";
 import { Transaction } from "../DispatcherPayloadMeta";
-import { EventEmitter } from "events";
+import { Dispatcher } from "../Dispatcher";
 
 const canUsePerformanceMeasure: boolean =
     typeof performance !== "undefined" &&
@@ -13,7 +13,48 @@ const canUsePerformanceMeasure: boolean =
     typeof performance.measure === "function" &&
     typeof performance.clearMeasures === "function";
 
-export class AlminPerfMarker extends EventEmitter implements AlminPerfMarkerAbstract {
+export type AlminPerfMarkerActions =
+    | {
+          type: "beforeStoreGroupReadPhase";
+      }
+    | {
+          type: "afterStoreGroupReadPhase";
+      }
+    | {
+          type: "beforeStoreGroupWritePhase";
+      }
+    | {
+          type: "afterStoreGroupWritePhase";
+      }
+    | {
+          type: "beforeStoreGetState";
+      }
+    | {
+          type: "afterStoreGetState";
+      }
+    | {
+          type: "beforeStoreReceivePayload";
+      }
+    | {
+          type: "afterStoreReceivePayload";
+      }
+    | {
+          type: "willUseCaseExecute";
+      }
+    | {
+          type: "didUseCaseExecute";
+      }
+    | {
+          type: "completeUseCaseExecute";
+      }
+    | {
+          type: "beginTransaction";
+      }
+    | {
+          type: "endTransaction";
+      };
+
+export class AlminPerfMarker extends Dispatcher<AlminPerfMarkerActions> implements AlminPerfMarkerAbstract {
     private _isProfiling = false;
 
     beginProfile(): void {
@@ -58,51 +99,51 @@ export class AlminPerfMarker extends EventEmitter implements AlminPerfMarkerAbst
 
     beforeStoreGroupReadPhase(debugId: DebugId, _storeGroup: StoreGroupLike): void {
         this.markBegin(debugId, "StoreGroup#read");
-        this.emit("beforeStoreGroupReadPhase");
+        this.dispatch({ type: "beforeStoreGroupReadPhase" });
     }
 
     afterStoreGroupReadPhase(debugId: DebugId, storeGroup: StoreGroupLike): void {
         const displayName = storeGroup.name;
         this.markEnd(debugId, "StoreGroup#read", displayName);
-        this.emit("afterStoreGroupReadPhase");
+        this.dispatch({ type: "afterStoreGroupReadPhase" });
     }
 
     beforeStoreGroupWritePhase(debugId: DebugId, _storeGroup: StoreGroupLike): void {
         this.markBegin(debugId, "StoreGroup#write");
-        this.emit("beforeStoreGroupWritePhase");
+        this.dispatch({ type: "beforeStoreGroupWritePhase" });
     }
 
     afterStoreGroupWritePhase(debugId: DebugId, storeGroup: StoreGroupLike): void {
         const displayName = storeGroup.name;
         this.markEnd(debugId, "StoreGroup#write", displayName);
-        this.emit("afterStoreGroupWritePhase");
+        this.dispatch({ type: "afterStoreGroupWritePhase" });
     }
 
     beforeStoreGetState(debugId: DebugId, _store: StoreLike): void {
         this.markBegin(debugId, "Store#getState");
-        this.emit("beforeStoreGetState");
+        this.dispatch({ type: "beforeStoreGetState" });
     }
 
     afterStoreGetState(debugId: DebugId, store: StoreLike): void {
         const displayName = store.name;
         this.markEnd(debugId, "Store#getState", displayName);
-        this.emit("afterStoreGetState");
+        this.dispatch({ type: "afterStoreGetState" });
     }
 
     beforeStoreReceivePayload(debugId: DebugId, _store: StoreLike): void {
         this.markBegin(debugId, "Store#receivePayload");
-        this.emit("beforeStoreReceivePayload");
+        this.dispatch({ type: "beforeStoreReceivePayload" });
     }
 
     afterStoreReceivePayload(debugId: DebugId, store: StoreLike): void {
         const displayName = store.name;
         this.markEnd(debugId, "Store#receivePayload", displayName);
-        this.emit("afterStoreReceivePayload");
+        this.dispatch({ type: "afterStoreReceivePayload" });
     }
 
     willUseCaseExecute(debugId: DebugId, _useCase: UseCaseLike): void {
         this.markBegin(debugId, "UserCase#execute");
-        this.emit("willUseCaseExecute");
+        this.dispatch({ type: "willUseCaseExecute" });
     }
 
     didUseCaseExecute(debugId: DebugId, useCase: UseCaseLike): void {
@@ -110,23 +151,23 @@ export class AlminPerfMarker extends EventEmitter implements AlminPerfMarkerAbst
         this.markEnd(debugId, "UserCase#execute", displayName);
         // did -> complete
         this.markBegin(debugId, "UserCase#complete");
-        this.emit("didUseCaseExecute");
+        this.dispatch({ type: "didUseCaseExecute" });
     }
 
     completeUseCaseExecute(debugId: DebugId, useCase: UseCaseLike): void {
         const displayName = useCase.name;
         this.markEnd(debugId, "UserCase#complete", displayName);
-        this.emit("completeUseCaseExecute");
+        this.dispatch({ type: "completeUseCaseExecute" });
     }
 
     beginTransaction(debugId: string, _transaction: Transaction): void {
         this.markBegin(debugId, "Transaction");
-        this.emit("beginTransaction");
+        this.dispatch({ type: "beginTransaction" });
     }
 
     endTransaction(debugId: string, transaction: Transaction): void {
         const displayName = transaction.name;
         this.markEnd(debugId, "Transaction", displayName);
-        this.emit("endTransaction");
+        this.dispatch({ type: "endTransaction" });
     }
 }

--- a/packages/almin/test/AlminPerfMarker-test.ts
+++ b/packages/almin/test/AlminPerfMarker-test.ts
@@ -28,21 +28,6 @@ describe("AlminPerfMarker", () => {
             }
         });
 
-        const events = [
-            "beforeStoreGroupReadPhase",
-            "afterStoreGroupReadPhase",
-            "beforeStoreGroupWritePhase",
-            "afterStoreGroupWritePhase",
-            "beforeStoreGetState",
-            "afterStoreGetState",
-            "beforeStoreReceivePayload",
-            "afterStoreReceivePayload",
-            "willUseCaseExecute",
-            "didUseCaseExecute",
-            "completeUseCaseExecute",
-            "beginTransaction",
-            "endTransaction"
-        ];
         const expected = [
             "beginTransaction",
             "willUseCaseExecute",
@@ -61,10 +46,8 @@ describe("AlminPerfMarker", () => {
         const markedEvents: string[] = [];
         const debugTool = AlminInstruments.debugTool as AlminPerfMarker;
         if (debugTool) {
-            events.forEach(event => {
-                debugTool.on(event, () => {
-                    markedEvents.push(event);
-                });
+            debugTool.onDispatch(action => {
+                markedEvents.push(action.type);
             });
         }
 


### PR DESCRIPTION
Use `Dispatcher` class insteadof `events`.

We will remove the dependencies to `events` in the future.

### Pros

- Reduce file size
- Perf?
- React Native compatible
   - React Native bundler does not includes `events` by default