### PR TITLE
 fix(almin): make `UseCaseExecutor#execute` type complete

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,7 @@
     "textlint-rule-alex": "^1.0.1",
     "textlint-rule-common-misspellings": "^1.0.1",
     "textlint-rule-no-dead-link": "^4.3.0",
-    "textlint-rule-prh": "^5.0.1",
-    "typescript": "~2.9.1"
+    "textlint-rule-prh": "^5.0.1"
   },
   "scripts": {
     "precommit": "lint-staged",

--- a/packages/@almin/react-context/package.json
+++ b/packages/@almin/react-context/package.json
@@ -56,9 +56,9 @@
     "react": "^16.4.0",
     "react-dom": "^16.4.0",
     "rimraf": "^2.6.2",
-    "ts-node": "^6.1.0",
-    "ts-node-test-register": "^3.0.0",
-    "typescript": "^2.9.1"
+    "ts-node": "^7.0.1",
+    "ts-node-test-register": "^4.0.0",
+    "typescript": "^3.0.1"
   },
   "peerDependencies": {
     "react": ">=16.3.0"

--- a/packages/@almin/store-test-helper/package.json
+++ b/packages/@almin/store-test-helper/package.json
@@ -51,9 +51,9 @@
     "mocha": "^5.2.0",
     "prettier": "^1.13.5",
     "rimraf": "^2.6.2",
-    "ts-node": "^6.1.0",
-    "ts-node-test-register": "^3.0.0",
-    "typescript": "^2.9.1"
+    "ts-node": "^7.0.1",
+    "ts-node-test-register": "^4.0.0",
+    "typescript": "^3.0.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@almin/usecase-bus/package.json
+++ b/packages/@almin/usecase-bus/package.json
@@ -49,9 +49,9 @@
     "mocha": "^5.2.0",
     "prettier": "^1.13.5",
     "rimraf": "^2.6.2",
-    "ts-node": "^6.1.0",
-    "ts-node-test-register": "^3.0.0",
-    "typescript": "^2.9.1"
+    "ts-node": "^7.0.1",
+    "ts-node-test-register": "^4.0.0",
+    "typescript": "^3.0.1"
   },
   "peerDependencies": {
     "almin": ">=0.16.0"

--- a/packages/almin-logger/package.json
+++ b/packages/almin-logger/package.json
@@ -52,7 +52,7 @@
     "power-assert": "^1.5.0",
     "rimraf": "^2.6.2",
     "simple-mock": "^0.8.0",
-    "typescript": "~2.9.1",
+    "typescript": "~3.0.1",
     "webpack": "^3.8.1",
     "zuul": "^3.10.1"
   },

--- a/packages/almin-react-container/package.json
+++ b/packages/almin-react-container/package.json
@@ -53,8 +53,8 @@
     "react": "^16.4.0",
     "react-dom": "^16.4.0",
     "rimraf": "^2.6.2",
-    "ts-node": "^6.1.0",
-    "typescript": "~2.9.1"
+    "ts-node": "^7.0.1",
+    "typescript": "~3.0.1"
   },
   "peerDependencies": {
     "almin": "^0.15.0",

--- a/packages/almin/package.json
+++ b/packages/almin/package.json
@@ -70,9 +70,9 @@
     "sinon": "^4.5.0",
     "size-limit": "^0.17.0",
     "source-map-support": "^0.5.5",
-    "ts-node": "^6.1.0",
-    "ts-node-test-register": "^3.0.0",
-    "typescript": "~2.9.1",
+    "ts-node": "^7.0.1",
+    "ts-node-test-register": "^4.0.0",
+    "typescript": "~3.0.1",
     "typings-tester": "^0.3.1",
     "zuul": "^3.10.1"
   },

--- a/packages/almin/src/UseCaseExecutor.ts
+++ b/packages/almin/src/UseCaseExecutor.ts
@@ -58,6 +58,7 @@ interface newProxifyUseCaseArgs {
     onDidExecute(result?: any): void;
 
     onError(error: Error): void;
+
 }
 
 /**
@@ -149,6 +150,8 @@ export interface UseCaseExecutor<T extends UseCaseLike> extends Dispatcher {
     executor(executor: (useCase: Pick<T, "execute">) => any): Promise<void>;
 
     release(): void;
+
+    onRelease(handler: () => void): void;
 }
 
 /**
@@ -299,7 +302,8 @@ export class UseCaseExecutorImpl<T extends UseCaseLike> extends Dispatcher imple
     }
 
     /**
-     * @private like
+     * Call handler when this UseCaseExecutor will be released
+     * @param handler
      */
     onRelease(handler: () => void): void {
         this.on("USECASE_EXECUTOR_RELEASE", handler);

--- a/packages/almin/src/UseCaseExecutorFactory.ts
+++ b/packages/almin/src/UseCaseExecutorFactory.ts
@@ -1,4 +1,4 @@
-import { UseCaseExecutorImpl } from "./UseCaseExecutor";
+import { UseCaseExecutor, UseCaseExecutorImpl } from "./UseCaseExecutor";
 import { isUseCaseFunction, UseCaseFunction } from "./FunctionalUseCaseContext";
 import { FunctionalUseCase } from "./FunctionalUseCase";
 import { isUseCase, UseCase } from "./UseCase";
@@ -9,8 +9,8 @@ export function createUseCaseExecutor(
     useCase: UseCaseFunction,
     dispatcher: Dispatcher
 ): UseCaseExecutorImpl<FunctionalUseCase>;
-export function createUseCaseExecutor<T extends UseCase>(useCase: T, dispatcher: Dispatcher): UseCaseExecutorImpl<T>;
-export function createUseCaseExecutor(useCase: any, dispatcher: Dispatcher): UseCaseExecutorImpl<any> {
+export function createUseCaseExecutor<T extends UseCase>(useCase: T, dispatcher: Dispatcher): UseCaseExecutor<T>;
+export function createUseCaseExecutor(useCase: any, dispatcher: Dispatcher): UseCaseExecutor<any> {
     // instance of UseCase
     if (isUseCase(useCase)) {
         return new UseCaseExecutorImpl({

--- a/packages/almin/test/Context-test.ts
+++ b/packages/almin/test/Context-test.ts
@@ -236,7 +236,12 @@ describe("Context", function() {
                 dispatcher,
                 store: createStore({ name: "test" })
             });
-            const testUseCase = new TestUseCase();
+
+            class OneArgumentUseCase extends UseCase {
+                execute(_oneArgument: string) {}
+            }
+
+            const oneArgumentUseCase = new OneArgumentUseCase();
             const expectedArguments = "param";
             // then
             appContext.events.onWillExecuteEachUseCase((payload, _meta) => {
@@ -246,7 +251,7 @@ describe("Context", function() {
                 done();
             });
             // when
-            appContext.useCase(testUseCase).execute(expectedArguments);
+            return appContext.useCase(oneArgumentUseCase).execute(expectedArguments);
         });
     });
     describe("#onDispatch", function() {

--- a/packages/almin/type-test/typing-fixtures/execute-argument.ts
+++ b/packages/almin/type-test/typing-fixtures/execute-argument.ts
@@ -5,6 +5,7 @@ class MyStore extends Store<{}> {
         super();
         this.name = args.name;
     }
+
     getState() {
         return {};
     }
@@ -31,7 +32,7 @@ class MyUseCaseOptional extends UseCase {
 }
 
 class MyUseCaseDefault extends UseCase {
-    execute(_value: string = "string") {}
+    execute(_value: string = "default value") {}
 }
 
 const context = new Context({
@@ -63,13 +64,8 @@ context.useCase(new MyUseCaseObj()).execute({ a: 1, b: 2 });
 // typings:expect-error
 context.useCase(new MyUseCaseOptional()).execute(1, 1);
 // typings:expect-error
-context.useCase(new MyUseCaseDefault()).execute(1);
-
-// =====
-// FIXME: These are should be Error, but current not support
-// =====
-// more arguments
-
 context.useCase(new MyUseCaseA()).execute("A", 1, 1);
 // typings:expect-error
 context.useCase(new MyUseCaseA()).executor(useCase => useCase.execute("A", 1, 1));
+// typings:expect-error
+context.useCase(new MyUseCaseDefault()).execute({ "incompatible type": 1 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -163,43 +163,17 @@
   version "9.4.7"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-9.4.7.tgz#57d81cd98719df2c9de118f2d5f3b1120dcd7275"
 
-"@types/prop-types@*":
-  version "15.5.5"
-  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.5.5.tgz#17038dd322c2325f5da650a94d5f9974943625e3"
-  dependencies:
-    "@types/react" "*"
-
-"@types/react-dom@16.0.6":
-  version "16.0.6"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.0.6.tgz#f1a65a4e7be8ed5d123f8b3b9eacc913e35a1a3c"
+"@types/react-dom@16.0.5", "@types/react-dom@16.0.6", "@types/react-dom@^16.0.6":
+  version "16.0.5"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.0.5.tgz#a757457662e3819409229e8f86795ff37b371f96"
   dependencies:
     "@types/node" "*"
     "@types/react" "*"
 
-"@types/react-dom@^16.0.6":
-  version "16.0.7"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.0.7.tgz#54d0f867a76b90597e8432030d297982f25c20ba"
-  dependencies:
-    "@types/node" "*"
-    "@types/react" "*"
-
-"@types/react@*":
+"@types/react@*", "@types/react@16.3.13", "@types/react@16.3.17", "@types/react@^16.3.17":
   version "16.3.13"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.3.13.tgz#47d466462b774556c1174ea0eda22c0578643362"
   dependencies:
-    csstype "^2.2.0"
-
-"@types/react@16.3.17":
-  version "16.3.17"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.3.17.tgz#d59d1a632570b0713946ed9c2949d994773633c5"
-  dependencies:
-    csstype "^2.2.0"
-
-"@types/react@^16.3.17":
-  version "16.4.11"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.4.11.tgz#330f3d864300f71150dc2d125e48644c098f8770"
-  dependencies:
-    "@types/prop-types" "*"
     csstype "^2.2.0"
 
 "@types/sinon@^4.3.1":

--- a/yarn.lock
+++ b/yarn.lock
@@ -9364,10 +9364,6 @@ typescript@^3.0.1, typescript@~3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.0.1.tgz#43738f29585d3a87575520a4b93ab6026ef11fdb"
 
-typescript@~2.9.1:
-  version "2.9.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.1.tgz#fdb19d2c67a15d11995fd15640e373e09ab09961"
-
 typings-tester@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/typings-tester/-/typings-tester-0.3.1.tgz#53bb9784b0ebd7b93192e6fcd908f14501af3878"

--- a/yarn.lock
+++ b/yarn.lock
@@ -163,17 +163,43 @@
   version "9.4.7"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-9.4.7.tgz#57d81cd98719df2c9de118f2d5f3b1120dcd7275"
 
-"@types/react-dom@16.0.5", "@types/react-dom@16.0.6", "@types/react-dom@^16.0.6":
-  version "16.0.5"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.0.5.tgz#a757457662e3819409229e8f86795ff37b371f96"
+"@types/prop-types@*":
+  version "15.5.5"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.5.5.tgz#17038dd322c2325f5da650a94d5f9974943625e3"
+  dependencies:
+    "@types/react" "*"
+
+"@types/react-dom@16.0.6":
+  version "16.0.6"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.0.6.tgz#f1a65a4e7be8ed5d123f8b3b9eacc913e35a1a3c"
   dependencies:
     "@types/node" "*"
     "@types/react" "*"
 
-"@types/react@*", "@types/react@16.3.13", "@types/react@16.3.17", "@types/react@^16.3.17":
+"@types/react-dom@^16.0.6":
+  version "16.0.7"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.0.7.tgz#54d0f867a76b90597e8432030d297982f25c20ba"
+  dependencies:
+    "@types/node" "*"
+    "@types/react" "*"
+
+"@types/react@*":
   version "16.3.13"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.3.13.tgz#47d466462b774556c1174ea0eda22c0578643362"
   dependencies:
+    csstype "^2.2.0"
+
+"@types/react@16.3.17":
+  version "16.3.17"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.3.17.tgz#d59d1a632570b0713946ed9c2949d994773633c5"
+  dependencies:
+    csstype "^2.2.0"
+
+"@types/react@^16.3.17":
+  version "16.4.11"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.4.11.tgz#330f3d864300f71150dc2d125e48644c098f8770"
+  dependencies:
+    "@types/prop-types" "*"
     csstype "^2.2.0"
 
 "@types/sinon@^4.3.1":
@@ -1615,6 +1641,10 @@ buffer-crc32@~0.2.1:
 buffer-from@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.0.0.tgz#4cb8832d23612589b0406e9e2956c17f06fdf531"
+
+buffer-from@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
 
 buffer-xor@^1.0.3:
   version "1.0.3"
@@ -9286,17 +9316,18 @@ tryer@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/tryer/-/tryer-1.0.0.tgz#027b69fa823225e551cace3ef03b11f6ab37c1d7"
 
-ts-node-test-register@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/ts-node-test-register/-/ts-node-test-register-3.0.0.tgz#6b0397a7e3153dcfb9bf6cad48bd79a90674fe2a"
+ts-node-test-register@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/ts-node-test-register/-/ts-node-test-register-4.0.0.tgz#dcf35a1eb6d0608a799886108311d3654a2b1fb9"
   dependencies:
     read-pkg "^3.0.0"
 
-ts-node@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-6.1.0.tgz#a2c37a11fdb58e60eca887a1269b025cf4d2f8b8"
+ts-node@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-7.0.1.tgz#9562dc2d1e6d248d24bc55f773e3f614337d9baf"
   dependencies:
     arrify "^1.0.0"
+    buffer-from "^1.1.0"
     diff "^3.1.0"
     make-error "^1.1.1"
     minimist "^1.2.0"
@@ -9355,7 +9386,11 @@ typedarray@^0.0.6, typedarray@~0.0.5:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@^2.9.1, typescript@~2.9.1:
+typescript@^3.0.1, typescript@~3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.0.1.tgz#43738f29585d3a87575520a4b93ab6026ef11fdb"
+
+typescript@~2.9.1:
   version "2.9.1"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.1.tgz#fdb19d2c67a15d11995fd15640e373e09ab09961"
 


### PR DESCRIPTION
This PR will fix the caveats of #342 

```ts
type Arguments<F extends (...x: any[]) => any> =
        F extends (...x: infer A) => any ? A : never;
```


- Require [TypeScript 3.0+](https://blogs.msdn.microsoft.com/typescript/2018/07/30/announcing-typescript-3-0/)

Refs #342
fix #107 