### PR TITLE
Almin 0.19.0

### DIFF
--- a/packages/@almin/react-context/CHANGELOG.md
+++ b/packages/@almin/react-context/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.1.4](https://github.com/almin/almin/compare/@almin/react-context@1.1.3...@almin/react-context@1.1.4) (2020-07-12)
+
+**Note:** Version bump only for package @almin/react-context
+
+
+
+
+
 <a name="1.1.3"></a>
 ## [1.1.3](https://github.com/almin/almin/compare/@almin/react-context@1.1.2...@almin/react-context@1.1.3) (2018-08-30)
 

--- a/packages/@almin/react-context/package.json
+++ b/packages/@almin/react-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@almin/react-context",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "React Context wrapper for almin.",
   "keywords": [
     "almin",
@@ -43,12 +43,12 @@
     "tabWidth": 4
   },
   "devDependencies": {
-    "@almin/store-test-helper": "^1.1.3",
+    "@almin/store-test-helper": "^1.1.4",
     "@types/mocha": "^7.0.2",
     "@types/node": "^14.0.22",
     "@types/react": "^16.9.43",
     "@types/react-dom": "^16.9.8",
-    "almin": "^0.18.1",
+    "almin": "^0.19.0",
     "cross-env": "^7.0.2",
     "jsdom": "^15.2.1",
     "mocha": "^8.0.1",

--- a/packages/@almin/store-test-helper/CHANGELOG.md
+++ b/packages/@almin/store-test-helper/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.1.4](https://github.com/almin/almin/compare/@almin/store-test-helper@1.1.3...@almin/store-test-helper@1.1.4) (2020-07-12)
+
+**Note:** Version bump only for package @almin/store-test-helper
+
+
+
+
+
 <a name="1.1.3"></a>
 ## [1.1.3](https://github.com/almin/almin/compare/@almin/store-test-helper@1.1.2...@almin/store-test-helper@1.1.3) (2018-08-30)
 

--- a/packages/@almin/store-test-helper/package.json
+++ b/packages/@almin/store-test-helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@almin/store-test-helper",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Create Store helper for testing.",
   "keywords": [
     "almin",
@@ -42,7 +42,7 @@
     "tabWidth": 4
   },
   "dependencies": {
-    "almin": "^0.18.1"
+    "almin": "^0.19.0"
   },
   "devDependencies": {
     "@types/mocha": "^7.0.2",

--- a/packages/@almin/usecase-bus/CHANGELOG.md
+++ b/packages/@almin/usecase-bus/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.2.3](https://github.com/almin/almin/compare/@almin/usecase-bus@1.2.2...@almin/usecase-bus@1.2.3) (2020-07-12)
+
+**Note:** Version bump only for package @almin/usecase-bus
+
+
+
+
+
 <a name="1.2.2"></a>
 ## [1.2.2](https://github.com/almin/almin/compare/@almin/usecase-bus@1.2.1...@almin/usecase-bus@1.2.2) (2018-08-30)
 

--- a/packages/@almin/usecase-bus/package.json
+++ b/packages/@almin/usecase-bus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@almin/usecase-bus",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "A mediator for UseCase and Command.",
   "keywords": [
     "almin",
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@types/mocha": "^7.0.2",
     "@types/node": "^14.0.22",
-    "almin": "^0.18.1",
+    "almin": "^0.19.0",
     "cross-env": "^7.0.2",
     "mocha": "^8.0.1",
     "prettier": "^2.0.5",

--- a/packages/almin-logger/CHANGELOG.md
+++ b/packages/almin-logger/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.2.4](https://github.com/almin/almin/compare/almin-logger@6.2.3...almin-logger@6.2.4) (2020-07-12)
+
+**Note:** Version bump only for package almin-logger
+
+
+
+
+
 <a name="6.2.3"></a>
 ## [6.2.3](https://github.com/almin/almin/compare/almin-logger@6.2.2...almin-logger@6.2.3) (2018-08-30)
 

--- a/packages/almin-logger/package.json
+++ b/packages/almin-logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "almin-logger",
-  "version": "6.2.3",
+  "version": "6.2.4",
   "description": "logger for Almin.js",
   "keywords": [
     "almin",
@@ -43,10 +43,10 @@
     "map-like": "^2.0.0"
   },
   "devDependencies": {
-    "@almin/store-test-helper": "^1.1.3",
+    "@almin/store-test-helper": "^1.1.4",
     "@types/mocha": "^7.0.2",
     "@types/node": "^14.0.22",
-    "almin": "^0.18.1",
+    "almin": "^0.19.0",
     "cross-env": "^7.0.2",
     "mocha": "^8.0.1",
     "power-assert": "^1.6.1",

--- a/packages/almin-react-container/CHANGELOG.md
+++ b/packages/almin-react-container/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.7.4](https://github.com/almin/almin/compare/almin-react-container@0.7.3...almin-react-container@0.7.4) (2020-07-12)
+
+
+### Bug Fixes
+
+* **deps:** update dependency almin to ^0.18.1 ([b488e76](https://github.com/almin/almin/commit/b488e76b1b6318e48d7b7b8dff0245dd0761b432))
+* **deps:** update dependency prop-types to ^15.7.2 ([a6d10cd](https://github.com/almin/almin/commit/a6d10cdee688f3bca72bb1b78d9a5ce4b80a53b7))
+* **deps:** update dependency shallow-equal-object to ^1.1.1 ([2734178](https://github.com/almin/almin/commit/2734178e7f53448903e1217d1655a441ec5bcd30))
+
+
+
+
+
 <a name="0.7.3"></a>
 ## [0.7.3](https://github.com/almin/almin/compare/almin-react-container@0.7.2...almin-react-container@0.7.3) (2018-08-30)
 

--- a/packages/almin-react-container/package.json
+++ b/packages/almin-react-container/package.json
@@ -1,6 +1,6 @@
 {
   "name": "almin-react-container",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "React bindings for Almin",
   "keywords": [
     "almin",
@@ -41,7 +41,7 @@
     "@types/node": "^14.0.22",
     "@types/react": "16.9.43",
     "@types/react-dom": "16.9.8",
-    "almin": "^0.18.1",
+    "almin": "^0.19.0",
     "babel-preset-env": "^1.7.0",
     "babel-preset-power-assert": "^1.0.0",
     "babel-preset-react": "^6.24.1",

--- a/packages/almin/CHANGELOG.md
+++ b/packages/almin/CHANGELOG.md
@@ -3,6 +3,32 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.19.0](https://github.com/almin/almin/compare/almin@0.18.1...almin@0.19.0) (2020-07-12)
+
+
+### Bug Fixes
+
+* **almin:** drop flow type support ([#427](https://github.com/almin/almin/issues/427)) ([9714b9a](https://github.com/almin/almin/commit/9714b9a65e56bf94c63d1770389ba403f160df73))
+* **deps:** update dependency shallow-equal-object to ^1.1.1 ([2734178](https://github.com/almin/almin/commit/2734178e7f53448903e1217d1655a441ec5bcd30))
+
+
+### Features
+
+* **almin:** support module field ([#422](https://github.com/almin/almin/issues/422)) ([70ffbb4](https://github.com/almin/almin/commit/70ffbb468f2dfe6d3eb04930867a74e4c56e9431)), closes [#354](https://github.com/almin/almin/issues/354)
+
+
+### BREAKING CHANGES
+
+* **almin:** Drop flow type support
+
+* chore(examples): remove flow example
+
+* chore(almin): remove unused command
+
+
+
+
+
 <a name="0.18.1"></a>
 ## [0.18.1](https://github.com/almin/almin/compare/almin@0.18.0...almin@0.18.1) (2018-08-30)
 

--- a/packages/almin/package.json
+++ b/packages/almin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "almin",
-  "version": "0.18.1",
+  "version": "0.19.0",
   "description": "Client-side DDD/CQRS for JavaScript.",
   "keywords": [
     "aluminium",


### PR DESCRIPTION
### BreakingChanges

- **almin:** Drop flow type support

### features

- **almin:** support module field ([#422](https://github.com/almin/almin/issues/422)) ([70ffbb4](https://github.com/almin/almin/commit/70ffbb468f2dfe6d3eb04930867a74e4c56e9431)), closes [#354](https://github.com/almin/almin/issues/354)

### fixes

- **almin:** drop flow type support ([#427](https://github.com/almin/almin/issues/427)) ([9714b9a](https://github.com/almin/almin/commit/9714b9a65e56bf94c63d1770389ba403f160df73))
- **deps:** update dependency shallow-equal-object to ^1.1.1 ([2734178](https://github.com/almin/almin/commit/2734178e7f53448903e1217d1655a441ec5bcd30))
